### PR TITLE
Fix classification hook filename

### DIFF
--- a/app/src/components/profile/EvaluateClassificationModal.tsx
+++ b/app/src/components/profile/EvaluateClassificationModal.tsx
@@ -22,7 +22,7 @@ import {
   ArrowUpRight,
 } from "lucide-react";
 import { mapSeniorityLevel } from "@/utils/mappings";
-import { useEvaluateClassifcation } from "@/hooks/profile/useEvaluateClassifcation";
+import { useEvaluateClassification } from "@/hooks/profile/useEvaluateClassification";
 import { useEvaluateSeniority } from "@/hooks/profile/useEvaluateSeniority";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
@@ -72,7 +72,7 @@ export function EvaluateClassificationModal({ role, trigger }: Props) {
   );
 
   const { mutate: evaluateClassification, isPending: classifPending } =
-    useEvaluateClassifcation({
+    useEvaluateClassification({
       onSuccess: () => {
         setClassificationEvaluated(true);
       },

--- a/app/src/hooks/profile/useEvaluateClassification.ts
+++ b/app/src/hooks/profile/useEvaluateClassification.ts
@@ -6,7 +6,7 @@ type Input = {
   onSuccess?: () => void | Promise<void>;
 };
 
-export const useEvaluateClassifcation = ({ onSuccess }: Input) => {
+export const useEvaluateClassification = ({ onSuccess }: Input) => {
   const qc = useQueryClient();
 
   const mutation = useMutation({


### PR DESCRIPTION
## Summary
- rename hook file to `useEvaluateClassification.ts`
- update imports to use new filename

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7b96634832593ea2fa8adb6159c