### PR TITLE
fix(analytics): reset page to 1 on filters change in Company dashboard

### DIFF
--- a/app/src/components/analytics/dashboards/CompanyDashboard.tsx
+++ b/app/src/components/analytics/dashboards/CompanyDashboard.tsx
@@ -63,6 +63,10 @@ export const CompanyDashboard = ({
     TrendFrequency.Y5
   );
 
+  useEffect(() => {
+    setPage(1);
+  }, [filters]);
+
   const needsNewData =
     page > 1 ||
     view === ViewType.TREND ||

--- a/app/src/components/analytics/dashboards/RoleDashboard.tsx
+++ b/app/src/components/analytics/dashboards/RoleDashboard.tsx
@@ -74,10 +74,6 @@ export const RoleDashboard = ({
     TrendFrequency.Y5
   );
 
-  useEffect(() => {
-    setPage(1);
-  }, [filters]);
-
   const needsNewData =
   page > 1 ||
   view === ViewType.TREND ||

--- a/app/src/components/analytics/dashboards/RoleDashboard.tsx
+++ b/app/src/components/analytics/dashboards/RoleDashboard.tsx
@@ -74,6 +74,10 @@ export const RoleDashboard = ({
     TrendFrequency.Y5
   );
 
+  useEffect(() => {
+    setPage(1);
+  }, [filters]);
+
   const needsNewData =
   page > 1 ||
   view === ViewType.TREND ||


### PR DESCRIPTION
This pull request introduces a small but important update to ensure pagination resets when the `filters` dependency changes in the `CompanyDashboard` component. This change improves the user experience by ensuring the displayed data aligns with the updated filters.

* [`app/src/components/analytics/dashboards/CompanyDashboard.tsx`](diffhunk://#diff-f7a166e4abe37f907a1e3f154982261236996bcd964f09db217da5baee301a0fR66-R69): Added a `useEffect` hook to reset the `page` state to 1 whenever the `filters` dependency changes.