### PR TITLE
fix: remove redundant private Redis access in UserService

### DIFF
--- a/api/src/otp/otp.service.ts
+++ b/api/src/otp/otp.service.ts
@@ -1,13 +1,10 @@
-import { Inject, Injectable } from '@nestjs/common';
-import Redis from 'ioredis';
+import { Injectable } from '@nestjs/common';
 import * as crypto from 'crypto';
+import { RedisService } from '../redis/redis.service';
 
 @Injectable()
 export class OtpService {
-  constructor(
-    @Inject('REDIS_CLIENT')
-    private readonly redis: Redis,
-  ) {}
+  constructor(private readonly redisService: RedisService) {}
 
   private hash(code: string) {
     return crypto.createHash('sha256').update(code).digest('hex');
@@ -17,17 +14,17 @@ export class OtpService {
     const otp = crypto.randomInt(100000, 999999).toString();
     const hashed = this.hash(otp);
 
-    await this.redis.set(`otp:${email}`, hashed, 'EX', 600); // 10 min
+    await this.redisService.set(`otp:${email}`, hashed, 600); // 10 min
 
     return otp;
   }
 
   async verifyOTP(email: string, code: string): Promise<boolean> {
     const hashed = this.hash(code);
-    const stored = await this.redis.get(`otp:${email}`);
+    const stored = await this.redisService.get(`otp:${email}`);
 
     if (stored && stored === hashed) {
-      await this.redis.del(`otp:${email}`);
+      await this.redisService.del(`otp:${email}`);
       return true;
     }
     return false;

--- a/api/src/redis/redis.module.ts
+++ b/api/src/redis/redis.module.ts
@@ -1,22 +1,9 @@
-import { Module, Global } from '@nestjs/common';
-import Redis from 'ioredis';
+import { Global, Module } from '@nestjs/common';
+import { RedisService } from './redis.service';
 
 @Global()
 @Module({
-  providers: [
-    {
-      provide: 'REDIS_CLIENT',
-      useFactory: () => {
-        return new Redis(
-          process.env.REDIS_URL || {
-            host: process.env.REDIS_HOST || 'localhost',
-            port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
-            password: process.env.REDIS_PASSWORD,
-          },
-        );
-      },
-    },
-  ],
-  exports: ['REDIS_CLIENT'],
+  providers: [RedisService],
+  exports: [RedisService],
 })
 export class RedisModule {}

--- a/api/src/redis/redis.service.ts
+++ b/api/src/redis/redis.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+@Injectable()
+export class RedisService implements OnModuleDestroy {
+  private readonly client: Redis;
+
+  constructor(private configService: ConfigService) {
+    this.client = new Redis(
+      this.configService.get<string>('REDIS_URL') || 'redis://localhost:6379',
+    );
+  }
+
+  async onModuleDestroy() {
+    await this.client.quit();
+  }
+
+  async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    if (ttlSeconds) {
+      await this.client.setex(key, ttlSeconds, value);
+    } else {
+      await this.client.set(key, value);
+    }
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.client.get(key);
+  }
+
+  async del(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+
+  async exists(key: string): Promise<boolean> {
+    const result = await this.client.exists(key);
+    return result === 1;
+  }
+
+  getClient(): Redis {
+    return this.client;
+  }
+}

--- a/api/src/redis/redis.service.ts
+++ b/api/src/redis/redis.service.ts
@@ -6,7 +6,7 @@ import Redis from 'ioredis';
 export class RedisService implements OnModuleDestroy {
   private readonly client: Redis;
 
-  constructor(private configService: ConfigService) {
+  constructor(private readonly configService: ConfigService) {
     this.client = new Redis(
       this.configService.get<string>('REDIS_URL') || 'redis://localhost:6379',
     );

--- a/api/src/redis/redis.service.ts
+++ b/api/src/redis/redis.service.ts
@@ -17,7 +17,7 @@ export class RedisService implements OnModuleDestroy {
   }
 
   async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
-    if (ttlSeconds) {
+    if (ttlSeconds !== undefined) {
       await this.client.setex(key, ttlSeconds, value);
     } else {
       await this.client.set(key, value);

--- a/api/src/user/services/user.service.ts
+++ b/api/src/user/services/user.service.ts
@@ -121,8 +121,6 @@ export class UserService {
     }
 
     const code = await this.otpService.generateOTP(email);
-    const hashed = this.otpService['hash'](code);
-    await this.otpService['redis'].set(`otp:${email}`, hashed, 'EX', 600);
 
     await this.emailService.sendOtpEmail(email, code);
   }


### PR DESCRIPTION
## Summary
- `generateOTP()` already hashes + stores the OTP in Redis via `RedisService` internally
- `UserService` was redundantly calling `otpService['hash']` and `otpService['redis'].set(...)` — private member access that broke after the `RedisService` refactor (#67)
- Removing the two dead lines fixes the `TS7053` build error on Railway

## Depends on
#67 (`refactor/redis-service`) — merge that first

## Test plan
- [ ] Railway build passes
- [ ] OTP send + verify flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)