### PR TITLE
fix(agents-api): replace hardcoded Redis localhost with REDIS_URL (CAR-107)

### DIFF
--- a/agents-api/.env.example
+++ b/agents-api/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL=""
+REDIS_URL="redis://localhost:6379/0"
 
 # *** API INFO ***
 PORT=8000

--- a/agents-api/app/agents/job_classification.py
+++ b/agents-api/app/agents/job_classification.py
@@ -110,7 +110,7 @@ def get_esco_prompt(retry_count: int = 0) -> str:
 
 class JobClassificationAgent:
     def __init__(self):
-        self._redis_cache = Redis(host="localhost", port=6379, db=0)
+        self._redis_cache = Redis.from_url(settings.REDIS_URL)
         self.CACHE_TTL = 60 * 60 * 24  # 24 hours
         self.MAX_RETRIES = 3
 

--- a/agents-api/app/agents/location.py
+++ b/agents-api/app/agents/location.py
@@ -125,7 +125,7 @@ tool_node = ToolNode(tools=tools)
 
 # Rate limiter to avoid exceeding OpenAI's 200k tokens/minute cap
 rate_limiter = TokenRateLimiter(
-    redis_client=Redis(host="localhost", port=6379, db=0),
+    redis_client=Redis.from_url(settings.REDIS_URL),
     distributed_key="openai_location_agent_rate_limiter",
 )
 
@@ -143,7 +143,7 @@ def count_tokens(messages: List[SystemMessage | HumanMessage]) -> int:
 
 class LocationAgent:
     def __init__(self):
-        self._redis_cache = Redis(host="localhost", port=6379, db=0)
+        self._redis_cache = Redis.from_url(settings.REDIS_URL)
         self.CACHE_TTL = 60 * 60 * 24  # 24 hours
         self.MAX_RETRIES = 3
         self._background_tasks = set()

--- a/agents-api/app/core/config.py
+++ b/agents-api/app/core/config.py
@@ -27,6 +27,9 @@ class Settings(BaseSettings):
     # Database Settings
     DATABASE_URL: PostgresDsn
 
+    # Redis Settings
+    REDIS_URL: str = "redis://localhost:6379/0"
+
     # OpenAI Settings
     OPENAI_DEFAULT_MODEL: str = "gpt-4o-mini"
     OPENAI_API_KEY: str = ""


### PR DESCRIPTION
## Summary

- Three callsites in `agents-api` hardcoded `Redis(host="localhost", port=6379, db=0)`, blocking any non-local deployment
- Add `REDIS_URL` to settings (default kept as `redis://localhost:6379/0` so local dev is unaffected)
- Switch all three callsites to `Redis.from_url(settings.REDIS_URL)`

## Files touched

- `agents-api/app/core/config.py` — new `REDIS_URL` setting
- `agents-api/.env.example` — document the new var
- `agents-api/app/agents/job_classification.py` — `JobClassificationAgent.__init__`
- `agents-api/app/agents/location.py` — module-level `TokenRateLimiter` + `LocationAgent.__init__`

Linear ticket only mentioned the `job_classification.py` callsite; flagged the other two via comment on CAR-107 and fixed all three in one go since the pattern is identical.

Closes CAR-107.

## Test plan

- [ ] Locally: agents-api starts with default `REDIS_URL` and `redis-cli ping` works
- [ ] Locally: override `REDIS_URL` to a different DB index and confirm the cache writes there
- [ ] Smoke-test classification endpoint to confirm Redis cache reads/writes still work
- [ ] On Railway: set `REDIS_URL=${{Redis.REDIS_URL}}` reference variable when the service is provisioned (CAR-123)

🤖 Generated with [Claude Code](https://claude.com/claude-code)