### PR TITLE
feat(agents-api): Railway deploy config (CAR-123)

### DIFF
--- a/agents-api/README.md
+++ b/agents-api/README.md
@@ -4,7 +4,7 @@ A FastAPI service for job title classification and LinkedIn data extraction.
 
 ## Features
 
-- Classify job titles into ESCO taxonomy using LLM agents (langchain/langGraph + ollama)
+- Classify job titles into ESCO taxonomy using LLM agents
 - Extract LinkedIn profile data
 - RESTful API endpoints with proper request/response validation
 - Connection to PostgreSQL database
@@ -13,7 +13,7 @@ A FastAPI service for job title classification and LinkedIn data extraction.
 
 - Python 3.12+
 - PostgreSQL database
-- Ollama (for LLM inference)
+- Redis
 
 ## Installation
 
@@ -182,6 +182,48 @@ Run tests using pytest:
 ```bash
 pytest
 ```
+
+## Deployment (Railway)
+
+The service deploys to Railway via Nixpacks. Build/runtime config lives in `nixpacks.toml` and `railway.toml`.
+
+### Required env vars
+
+Wire these as Railway service variables (use reference variables for `DATABASE_URL` and `REDIS_URL` so they pull from the Postgres / Redis add-ons):
+
+| Variable | Source | Notes |
+| --- | --- | --- |
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` | Same Postgres as the NestJS API |
+| `REDIS_URL` | `${{Redis.REDIS_URL}}` | Provision Redis as a Railway add-on |
+| `PORT` | auto-injected | Don't set manually |
+| `ENVIRONMENT` | `production` | |
+| `LOG_LEVEL` | `info` | |
+| `CORS_ORIGINS` | `["<nestjs-railway-url>","<frontend-url>"]` | JSON array as a string |
+| `API_KEY_SECRET` | random secret | Shared with the NestJS API for inter-service auth |
+| `OPENAI_API_KEY` | OpenAI dashboard | Required for embeddings (Anthropic has none) |
+| `OPENAI_DEFAULT_MODEL` | `gpt-4o-mini` | |
+| `ALUMNI_EXTRACT_API_KEY` | EnrichLayer | |
+| `ALUMNI_EXTRACT_BASE_URL` | EnrichLayer | |
+| `BRIGHTDATA_API_KEY` | BrightData | |
+| `BRIGHTDATA_BASE_URL` | BrightData | |
+| `BRIGHTDATA_COMPANY_DATASET_ID` | BrightData | |
+| `CLOUDINARY_CLOUD_NAME` | Cloudinary | |
+| `CLOUDINARY_API_KEY` | Cloudinary | |
+| `CLOUDINARY_API_SECRET` | Cloudinary | |
+| `GEOLOCATION_API_KEY` | OpenWeather | |
+| `GEOLOCATION_BASE_URL` | OpenWeather | `https://api.openweathermap.org/geo/1.0/direct?q=` |
+
+### Networking
+
+Call this service from the NestJS API via Railway's private network (`agents-api.railway.internal:$PORT`) instead of the public URL — free, no egress, no CORS for that hop. Public URL is only needed for healthchecks and ad-hoc debugging.
+
+### Sentence-transformers model cache
+
+`nixpacks.toml` pre-downloads `cross-encoder/ms-marco-MiniLM-L-6-v2` at build time into `/app/.cache/huggingface` (set via `HF_HOME`), so cold starts don't pay the ~90 MB download. No volume mount needed; the cache lives in the build image.
+
+### Healthcheck
+
+`GET /health` returns `{"status": "ok"}` and is exempt from `APIKeyMiddleware` (allowlisted in `app/core/middlewares.py`). Railway's healthcheck path is configured in `railway.toml`.
 
 ## License
 

--- a/agents-api/app/core/middlewares.py
+++ b/agents-api/app/core/middlewares.py
@@ -47,12 +47,18 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             raise
 
 
+PUBLIC_PATHS = {"/health"}
+
+
 class APIKeyMiddleware(BaseHTTPMiddleware):
     """
     Middleware to authenticate requests using an API key.
     """
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path in PUBLIC_PATHS:
+            return await call_next(request)
+
         # Get API key from header
         api_key = request.headers.get("X-API-Key")
 

--- a/agents-api/app/main.py
+++ b/agents-api/app/main.py
@@ -42,6 +42,12 @@ app.add_middleware(
 
 app.add_middleware(APIKeyMiddleware)
 
+
+@app.get("/health", tags=["health"])
+async def health():
+    return {"status": "ok"}
+
+
 # Include all routers
 app.include_router(api_router, prefix="/api")
 

--- a/agents-api/nixpacks.toml
+++ b/agents-api/nixpacks.toml
@@ -1,0 +1,25 @@
+# Nixpacks build config for Railway.
+#
+# Pinning Python 3.12 + uv explicitly so the build is reproducible across
+# nixpacks updates. The build phase pre-downloads the sentence-transformers
+# cross-encoder weights so cold starts don't pay the ~90 MB download cost.
+
+providers = ["python"]
+
+[variables]
+HF_HOME = "/app/.cache/huggingface"
+PYTHONUNBUFFERED = "1"
+
+[phases.setup]
+nixPkgs = ["python312", "uv"]
+
+[phases.install]
+cmds = ["uv sync --no-dev --frozen"]
+
+[phases.build]
+cmds = [
+  "uv run python -c \"from sentence_transformers.cross_encoder import CrossEncoder; CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2', device='cpu')\""
+]
+
+[start]
+cmd = "uv run uvicorn app.main:app --host 0.0.0.0 --port $PORT"

--- a/agents-api/railway.toml
+++ b/agents-api/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "NIXPACKS"
+
+[deploy]
+startCommand = "uv run uvicorn app.main:app --host 0.0.0.0 --port $PORT"
+healthcheckPath = "/health"
+healthcheckTimeout = 60
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary

- Add `nixpacks.toml` pinning Python 3.12 + uv and pre-downloading the sentence-transformers cross-encoder weights at build time (~90 MB) so cold starts don't pay it
- Add `railway.toml` with start command, `/health` healthcheck, and `ON_FAILURE` restart policy
- Add `GET /health` endpoint to `app/main.py` and allowlist it in `APIKeyMiddleware` (Railway healthcheck is unauthenticated)
- Update README with a Railway deployment section: full env-var checklist, private-networking note (use `*.railway.internal` for the NestJS → agents-api hop), and HF cache rationale. Drop stale Ollama mention from features list

## Files

- `agents-api/nixpacks.toml` (new)
- `agents-api/railway.toml` (new)
- `agents-api/app/main.py` — `/health` endpoint
- `agents-api/app/core/middlewares.py` — `PUBLIC_PATHS` allowlist
- `agents-api/README.md` — deployment section

## Out of scope

- Actually provisioning the Railway service / setting env vars via reference variables — that's a manual click-op (no Railway CLI access from here)
- Source-code refactors (CAR-107, CAR-115, CAR-119 are separate PRs)

Closes CAR-123.

## Test plan

- [ ] Railway service created pointing at `agents-api/` root
- [ ] `${{Postgres.DATABASE_URL}}` and `${{Redis.REDIS_URL}}` reference variables wired
- [ ] All env vars from the README table set
- [ ] First build completes, model pre-download step logs success
- [ ] `GET https://<service>.railway.app/health` returns `{"status":"ok"}` with 200
- [ ] NestJS API `AGENTS_API_URL` updated to `*.railway.internal` private hostname
- [ ] Smoke-test classification end-to-end (covered by CAR-102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)