### PR TITLE
fix(agents-api): explicit per-phase httpx timeouts + task-level pipeline timeouts

### DIFF
--- a/agents-api/app/services/company.py
+++ b/agents-api/app/services/company.py
@@ -22,6 +22,7 @@ from app.utils.industry_db import get_industry_by_name
 from app.utils.mappings import get_levels_fyi_name
 from app.utils.misc.convert import convert_company_size_to_enum, convert_company_type_to_enum
 from app.utils.misc.string import clean_website_url
+from app.utils.pipeline_timeout import with_pipeline_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +270,10 @@ class CompanyService:
             # Now that the company is updated, trigger location processing
             if company_response.headquarters and company_response.country_code:
                 # Execute location agent after company is saved to database
-                await location_agent.process_location(input)
+                await with_pipeline_timeout(
+                    location_agent.process_location(input),
+                    step="location.process_location",
+                )
         except Exception as e:
             logger.error(f"Error updating company {company_id}: {str(e)}")
             raise

--- a/agents-api/app/services/image_storage.py
+++ b/agents-api/app/services/image_storage.py
@@ -1,8 +1,8 @@
 import logging
 
 import cloudinary
-import cloudinary.uploader
 import cloudinary.exceptions
+import cloudinary.uploader
 
 from app.core.config import settings
 from app.db import get_db
@@ -55,7 +55,9 @@ class ImageStorageService:
             The secure URL of the uploaded image, or None if upload fails.
         """
         try:
-            upload_result = cloudinary.uploader.upload(image_url, public_id=public_id)
+            upload_result = cloudinary.uploader.upload(
+                image_url, public_id=public_id, timeout=60
+            )
             return upload_result["secure_url"]
         except (cloudinary.exceptions.Error, Exception) as e:
             logger.error(f"Failed to upload image {image_url}: {str(e)}")

--- a/agents-api/app/services/job_classification.py
+++ b/agents-api/app/services/job_classification.py
@@ -9,6 +9,7 @@ from app.schemas.job_classification import (
     AlumniJobClassificationParams,
 )
 from app.utils.alumni_db import find_all, find_by_ids
+from app.utils.pipeline_timeout import with_pipeline_timeout
 from app.utils.role_db import get_extended_roles_by_alumni_id
 
 logger = logging.getLogger(__name__)
@@ -31,7 +32,10 @@ class JobClassificationService:
 
             for i in range(0, len(roles), self.MAX_CONCURRENT):
                 batch = roles[i : i + self.MAX_CONCURRENT]
-                await job_classification_agent._process_roles_batch(batch, alumni_id)
+                await with_pipeline_timeout(
+                    job_classification_agent._process_roles_batch(batch, alumni_id),
+                    step="job_classification.process_roles_batch",
+                )
                 if i + self.MAX_CONCURRENT < len(roles):
                     await asyncio.sleep(0.1)
 

--- a/agents-api/app/services/linkedin.py
+++ b/agents-api/app/services/linkedin.py
@@ -30,6 +30,7 @@ from app.utils.consts import REMOTE_LOCATION_ID
 from app.utils.http_client import HTTPClient
 from app.utils.location_db import get_location
 from app.utils.misc.string import sanitize_linkedin_url
+from app.utils.pipeline_timeout import with_pipeline_timeout
 from app.utils.role_db import create_role, create_role_raw
 
 logger = logging.getLogger(__name__)
@@ -190,7 +191,12 @@ class LinkedInService:
                     country=country,
                     country_code=country_code,
                 )
-                self._create_background_task(location_agent.process_location(input))
+                self._create_background_task(
+                    with_pipeline_timeout(
+                        location_agent.process_location(input),
+                        step="location.process_location",
+                    )
+                )
 
             else:
                 location_id = location.id

--- a/agents-api/app/services/location.py
+++ b/agents-api/app/services/location.py
@@ -10,6 +10,7 @@ from app.schemas.location import (
     RoleLocationInput,
 )
 from app.services.coordinates import coordinates_service
+from app.utils.pipeline_timeout import with_pipeline_timeout
 from app.utils.role_db import (
     get_all_roles,
     get_role_raw_by_id,
@@ -62,7 +63,12 @@ class LocationService:
                     location=role_raw.location,
                 )
 
-                task = asyncio.create_task(location_agent.process_location(loc_input))
+                task = asyncio.create_task(
+                    with_pipeline_timeout(
+                        location_agent.process_location(loc_input),
+                        step="location.process_location",
+                    )
+                )
                 tasks.append(task)
 
             await asyncio.gather(*tasks)

--- a/agents-api/app/services/role.py
+++ b/agents-api/app/services/role.py
@@ -9,6 +9,7 @@ from app.schemas.location import LocationType, RoleLocationInput
 from app.schemas.role import RoleResolveLocationParams
 from app.utils.consts import REMOTE_LOCATION_ID
 from app.utils.misc.convert import linkedin_date_to_timestamp
+from app.utils.pipeline_timeout import with_pipeline_timeout
 from app.utils.role_db import (
     get_all_roles,
     get_role_raw_by_id,
@@ -66,7 +67,12 @@ class RoleService:
                     location=role_raw.location,
                 )
 
-                task = asyncio.create_task(location_agent.process_location(input))
+                task = asyncio.create_task(
+                    with_pipeline_timeout(
+                        location_agent.process_location(input),
+                        step="location.process_location",
+                    )
+                )
                 tasks.append(task)
 
             await asyncio.gather(*tasks)

--- a/agents-api/app/services/seniority.py
+++ b/agents-api/app/services/seniority.py
@@ -9,6 +9,7 @@ from app.db.models import Alumni, Role
 from app.db.session import get_db
 from app.schemas.seniority import AlumniSeniorityParams, BatchSeniorityInput, RoleSeniorityInput
 from app.utils.alumni_db import find_all, find_by_ids
+from app.utils.pipeline_timeout import with_pipeline_timeout
 from app.utils.role_db import get_roles_by_alumni_id
 
 logger = logging.getLogger(__name__)
@@ -146,7 +147,10 @@ class SeniorityService:
         
 
             async with self.semaphore:
-                await seniority_agent.process_role_batch(batch_input)
+                await with_pipeline_timeout(
+                    seniority_agent.process_role_batch(batch_input),
+                    step="seniority.process_role_batch",
+                )
 
         except Exception as e:
             logger.error(f"Error processing roles for alumni {alumni_id}: {str(e)}")

--- a/agents-api/app/utils/http_client.py
+++ b/agents-api/app/utils/http_client.py
@@ -6,12 +6,6 @@ from typing import Any, Dict, Optional, Union
 
 import httpx
 from httpx import Response
-
-# Per-phase timeout policy applied to every HTTPClient.
-# A single overall timeout lets a hung connect/write silently burn the read
-# budget; explicit per-phase values keep slow networks visible.
-DEFAULT_CONNECT_TIMEOUT = 10.0
-DEFAULT_WRITE_TIMEOUT = 10.0
 from tenacity import (
     before_sleep_log,
     retry,
@@ -21,6 +15,22 @@ from tenacity import (
 )
 
 from app.core.config import settings
+
+# Per-phase timeout policy applied to every HTTPClient.
+# A single overall timeout lets a hung connect/write silently burn the read
+# budget; explicit per-phase values keep slow networks visible.
+DEFAULT_CONNECT_TIMEOUT = 10.0
+DEFAULT_WRITE_TIMEOUT = 10.0
+
+# Retry on every per-phase timeout that explicit httpx.Timeout can surface,
+# so write/pool stalls get the same backoff treatment as connect/read.
+RETRYABLE_HTTPX_ERRORS = (
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
+    httpx.PoolTimeout,
+    httpx.ConnectError,
+)
 
 logger = logging.getLogger(__name__)
 # Disable noisy HTTPX logs
@@ -103,9 +113,7 @@ class HTTPClient:
             await self.async_client.aclose()
 
     @retry(
-        retry=retry_if_exception_type(
-            (httpx.ConnectTimeout, httpx.ReadTimeout, httpx.ConnectError)
-        ),
+        retry=retry_if_exception_type(RETRYABLE_HTTPX_ERRORS),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
         before_sleep=before_sleep_log(logger, logging.WARNING),
@@ -145,9 +153,7 @@ class HTTPClient:
             raise
 
     @retry(
-        retry=retry_if_exception_type(
-            (httpx.ConnectTimeout, httpx.ReadTimeout, httpx.ConnectError)
-        ),
+        retry=retry_if_exception_type(RETRYABLE_HTTPX_ERRORS),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
         before_sleep=before_sleep_log(logger, logging.WARNING),

--- a/agents-api/app/utils/http_client.py
+++ b/agents-api/app/utils/http_client.py
@@ -2,10 +2,16 @@
 
 import logging
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import httpx
 from httpx import Response
+
+# Per-phase timeout policy applied to every HTTPClient.
+# A single overall timeout lets a hung connect/write silently burn the read
+# budget; explicit per-phase values keep slow networks visible.
+DEFAULT_CONNECT_TIMEOUT = 10.0
+DEFAULT_WRITE_TIMEOUT = 10.0
 from tenacity import (
     before_sleep_log,
     retry,
@@ -29,7 +35,7 @@ class HTTPClient:
     def __init__(
         self,
         base_url: Optional[str] = None,
-        timeout: int = 30,
+        timeout: Union[int, float, httpx.Timeout] = 30,
         max_retries: int = 3,
         headers: Optional[Dict[str, str]] = None,
     ):
@@ -38,12 +44,24 @@ class HTTPClient:
 
         Args:
             base_url: Base URL for all requests
-            timeout: Request timeout in seconds
+            timeout: Read timeout in seconds (int/float) or full httpx.Timeout.
+                Plain int/float is converted to per-phase timeouts: connect/write
+                pinned to DEFAULT_CONNECT_TIMEOUT/DEFAULT_WRITE_TIMEOUT, read+pool
+                using the supplied value. Pass an httpx.Timeout directly for full
+                control.
             max_retries: Maximum number of retry attempts
             headers: Default headers for all requests
         """
         self.base_url = base_url
-        self.timeout = timeout
+        if isinstance(timeout, (int, float)):
+            self.timeout = httpx.Timeout(
+                connect=DEFAULT_CONNECT_TIMEOUT,
+                read=float(timeout),
+                write=DEFAULT_WRITE_TIMEOUT,
+                pool=float(timeout),
+            )
+        else:
+            self.timeout = timeout
         self.max_retries = max_retries
         self.default_headers = headers or {}
 

--- a/agents-api/app/utils/pipeline_timeout.py
+++ b/agents-api/app/utils/pipeline_timeout.py
@@ -35,7 +35,7 @@ async def with_pipeline_timeout(
     try:
         return await asyncio.wait_for(coro, timeout=seconds)
     except asyncio.TimeoutError:
-        logger.error(
+        logger.exception(
             f"Pipeline step '{step}' timed out after {seconds}s",
             extra={"step": step, "timeout_seconds": seconds},
         )

--- a/agents-api/app/utils/pipeline_timeout.py
+++ b/agents-api/app/utils/pipeline_timeout.py
@@ -1,0 +1,42 @@
+"""Task-level timeout helper for agent pipeline steps.
+
+A hung external HTTP/LLM call can stall a whole batch even when the underlying
+httpx clients have read timeouts, because retries and backoffs stack. Wrapping
+each pipeline step in `asyncio.wait_for()` puts a hard ceiling on how long any
+single step is allowed to run.
+"""
+
+import asyncio
+import logging
+from typing import Awaitable, TypeVar
+
+logger = logging.getLogger(__name__)
+
+# 300s = ~5 min. Generous enough to allow the underlying httpx retry cycle
+# (3 attempts * 60s read timeout + 1-10s exponential backoff) to exhaust
+# without prematurely cancelling slow-but-progressing batches.
+DEFAULT_PIPELINE_STEP_TIMEOUT = 300.0
+
+T = TypeVar("T")
+
+
+async def with_pipeline_timeout(
+    coro: Awaitable[T],
+    *,
+    step: str,
+    seconds: float = DEFAULT_PIPELINE_STEP_TIMEOUT,
+) -> T:
+    """Run a coroutine under a task-level timeout.
+
+    Re-raises asyncio.TimeoutError after logging context. Callers in the
+    batch path should catch and mark the corresponding BatchJobItem as
+    failed with reason="timeout" once that table exists (CAR-114).
+    """
+    try:
+        return await asyncio.wait_for(coro, timeout=seconds)
+    except asyncio.TimeoutError:
+        logger.error(
+            f"Pipeline step '{step}' timed out after {seconds}s",
+            extra={"step": step, "timeout_seconds": seconds},
+        )
+        raise


### PR DESCRIPTION
A single overall timeout lets a hung connect/write silently burn the read budget, and even with read timeouts in place, retry/backoff stacks can keep a "stuck" alumni in flight for minutes — stalling the rest of a batch.

Changes:

- HTTPClient: int/float `timeout` is now converted to `httpx.Timeout(connect=10, read=N, write=10, pool=N)` so connect/write are pinned regardless of the per-service read budget. Existing callsites (60s for EnrichLayer/BrightData/ OpenWeather, 5s for Levels.fyi) keep their read intent.
- New `app/utils/pipeline_timeout.py` exposes `with_pipeline_timeout(coro, *, step, seconds=300)` — wraps each pipeline entry point in `asyncio.wait_for()` with structured logging on timeout. Re-raises so callers can mark the corresponding BatchJobItem as failed (TODO once CAR-114 lands).
- Wrap the 6 pipeline entry points: location_agent.process_location (4 callsites), job_classification_agent._process_roles_batch, and seniority_agent.process_role_batch.
- Cloudinary upload now passes `timeout=60` (its SDK has no default).

Drive-by: fix pre-existing import-order lint in image_storage.py (cloudinary.exceptions before cloudinary.uploader) so ruff stays clean.