### PR TITLE
fix(agents-api): extract model prefetch into a script (Railpack quote bug)

### DIFF
--- a/agents-api/railpack.json
+++ b/agents-api/railpack.json
@@ -11,7 +11,7 @@
         "HF_HOME": "/app/.cache/huggingface"
       },
       "commands": [
-        "uv run python -c \"from sentence_transformers.cross_encoder import CrossEncoder; CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2', device='cpu')\""
+        "uv run python scripts/prefetch_models.py"
       ]
     }
   },

--- a/agents-api/scripts/prefetch_models.py
+++ b/agents-api/scripts/prefetch_models.py
@@ -1,0 +1,19 @@
+"""Pre-download model weights at build time so cold starts don't pay for it.
+
+Invoked by the `prefetch-models` step in railpack.json. Inlining the same
+command in railpack.json's JSON `commands` array does not work — Railpack's
+shell-out double-escapes the JSON-escaped `\"` and strips the inner single
+quotes, so the python -c invocation fails with a syntax error. A script file
+sidesteps the entire quoting problem.
+
+`HF_HOME` must be set in the same step so the cache lands in the layer
+that downstream steps inherit.
+"""
+
+from sentence_transformers.cross_encoder import CrossEncoder
+
+# Same model used by app/agents/* at runtime; keep in sync.
+MODEL_NAME = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+if __name__ == "__main__":
+    CrossEncoder(MODEL_NAME, device="cpu")


### PR DESCRIPTION
## Summary
- Hotfix for the failed Railpack build introduced in #78.
- Railpack 0.23.0 mangles JSON-escaped quotes in step commands: the JSON `\"` reaches the build daemon as a literal `\"` AND inner single quotes get stripped. Net result was a shell syntax error before Python was even invoked.
- Workaround: extract the cross-encoder prefetch into `scripts/prefetch_models.py` and have `railpack.json` invoke `uv run python scripts/prefetch_models.py` — no quoting in the JSON `commands` array at all.

## Repro from the failed build
```
$ uv run python -c \"from sentence_transformers.cross_encoder import CrossEncoder; CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2', device='cpu')\
sh: 1: Syntax error: word unexpected (expecting ")")
Build Failed: ... CrossEncoder(cross-encoder/ms-marco-MiniLM-L-6-v2, device=cpu) ...
```
Note the daemon echo dropped the inner `'` quotes too.

## Test plan
- [ ] Railway build picks up `scripts/prefetch_models.py`, the `prefetch-models` step prints HF download progress and completes in ~20s.
- [ ] Deploy step runs `uv run uvicorn ...`, container reaches `/health` returning 200.
- [ ] At runtime, agents that use the cross-encoder hit the cached weights at `/app/.cache/huggingface/...` (no download in service logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)