### PR TITLE
fix(agents-api): drop uv from runtime startCommand (Railpack split-image)

### DIFF
--- a/agents-api/railway.toml
+++ b/agents-api/railway.toml
@@ -2,7 +2,7 @@
 builder = "RAILPACK"
 
 [deploy]
-startCommand = "uv run uvicorn app.main:app --host 0.0.0.0 --port $PORT"
+startCommand = ".venv/bin/uvicorn app.main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"
 healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary
- Railpack uses separate build vs runtime images. `uv` is provisioned by mise in the build image but not in the deploy container.
- The previous `uv run uvicorn ...` startCommand fails on boot:
  ```
  /bin/bash: line 1: uv: command not found
  ```
- Switch to invoking uvicorn from the venv directly: `.venv/bin/uvicorn`. The venv is inherited into the deploy image via the `build` → `prefetch-models` → `deploy` input chain.

## Test plan
- [ ] Railway deploy log shows uvicorn booting (`Uvicorn running on http://0.0.0.0:$PORT`)
- [ ] `/health` returns 200 within the 60s healthcheck window
- [ ] NestJS API can call agents-api over `agents-api.railway.internal:$PORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)