### PR TITLE
test(agents-api): hermetic pytest harness + first agent tests (CAR-150, CAR-153)

### DIFF
--- a/agents-api/app/agents/location.py
+++ b/agents-api/app/agents/location.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import time
+from functools import lru_cache
 from typing import List
 
 import openai
@@ -130,14 +131,23 @@ rate_limiter = TokenRateLimiter(
 )
 
 # Helper to estimate token usage
-try:
-    encoding = tiktoken.encoding_for_model(settings.OPENAI_DEFAULT_MODEL)
-except KeyError:
-    # Fallback to cl100k_base which is used by GPT-4 and newer models
-    encoding = tiktoken.get_encoding("cl100k_base")
+@lru_cache(maxsize=1)
+def get_encoding() -> tiktoken.Encoding:
+    """Resolve the tokenizer on first use, not at import.
+
+    tiktoken downloads the BPE vocabulary when its cache is cold, so resolving
+    this at module scope made this module — and app.main, which imports it —
+    impossible to import without network access.
+    """
+    try:
+        return tiktoken.encoding_for_model(settings.OPENAI_DEFAULT_MODEL)
+    except KeyError:
+        # Fallback to cl100k_base which is used by GPT-4 and newer models
+        return tiktoken.get_encoding("cl100k_base")
 
 
 def count_tokens(messages: List[SystemMessage | HumanMessage]) -> int:
+    encoding = get_encoding()
     return sum(len(encoding.encode(m.content)) for m in messages)
 
 

--- a/agents-api/app/db/session.py
+++ b/agents-api/app/db/session.py
@@ -2,8 +2,7 @@ import logging
 from typing import Generator
 
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from app.core.config import settings

--- a/agents-api/app/utils/agents/esco_reference.py
+++ b/agents-api/app/utils/agents/esco_reference.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import List, TypedDict
 
 from langchain_core.tools import tool
@@ -10,7 +11,20 @@ from app.schemas.job_classification import EscoResult
 from app.utils.embeddings import generate_embedding
 from app.utils.esco_db import get_classification_by_code
 
-_cross_encoder = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2", device="cpu")
+# Keep in sync with scripts/prefetch_models.py, which warms the HF cache at build time.
+CROSS_ENCODER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+@lru_cache(maxsize=1)
+def get_cross_encoder() -> CrossEncoder:
+    """Load the reranker on first use, not at import.
+
+    Constructing a CrossEncoder reaches out to the HuggingFace Hub whenever the
+    local cache is cold, so doing it at module scope made this module — and
+    everything importing it, including app.main — impossible to import without
+    network access. Deferring the load also keeps it off the startup path.
+    """
+    return CrossEncoder(CROSS_ENCODER_MODEL, device="cpu")
 
 
 class EscoClassificationInfo(TypedDict):
@@ -130,6 +144,6 @@ def search_esco_classifications(query: str, top_k: int = 20) -> List[EscoResult]
 
 def rerank_esco(query: str, results: List[EscoResult], top_k: int = 5) -> List[EscoResult]:
     pairs = [[query, r.title] for r in results]
-    scores = _cross_encoder.predict(pairs)
+    scores = get_cross_encoder().predict(pairs)
     ranked = sorted(zip(results, scores), key=lambda x: x[1], reverse=True)
     return [r for r, _ in ranked[:top_k]]

--- a/agents-api/pyproject.toml
+++ b/agents-api/pyproject.toml
@@ -33,13 +33,6 @@ dependencies = [
     "prometheus-client>=0.22.0",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "ruff>=0.2.0",
-    "pytest>=7.4.0",
-    "mypy>=1.8.0",
-]
-
 [tool.ruff]
 line-length = 100
 target-version = "py312"
@@ -56,4 +49,32 @@ line-ending = "auto"
 [dependency-groups]
 dev = [
     "ruff>=0.11.4",
+    "mypy>=1.8.0",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=5.0.0",
+    "respx>=0.21.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# The app is deployed as an application, not installed as a package, so the
+# project root has to be put on sys.path for `import app.…` to resolve.
+pythonpath = ["."]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+addopts = "--strict-markers --strict-config"
+filterwarnings = [
+    "error::DeprecationWarning:app.*",
+]
+
+[tool.mypy]
+python_version = "3.12"
+files = ["app"]
+# Starting permissive and ratcheting per-module is far cheaper than a
+# big-bang typing PR. Tighten by adding [[tool.mypy.overrides]] blocks.
+ignore_missing_imports = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+check_untyped_defs = true

--- a/agents-api/tests/conftest.py
+++ b/agents-api/tests/conftest.py
@@ -35,7 +35,11 @@ import pytest  # noqa: E402
 
 # Loopback stays open so tests can reach a Postgres/Redis service container.
 # Everything else is refused.
-_ALLOWED_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "0.0.0.0"})
+#
+# 0.0.0.0 is deliberately absent: it is the wildcard *bind* address, not a
+# loopback one, and nothing connects to it as a destination. A container that
+# binds 0.0.0.0 is still reached over 127.0.0.1.
+_ALLOWED_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
 _real_connect = socket.socket.connect
 _real_connect_ex = socket.socket.connect_ex

--- a/agents-api/tests/conftest.py
+++ b/agents-api/tests/conftest.py
@@ -1,0 +1,110 @@
+"""Shared fixtures and the network guard.
+
+Environment is set here, at import time, because `app.core.config.Settings`
+declares `DATABASE_URL` as required and is evaluated the moment anything under
+`app.` is imported. pytest imports conftest before any test module, so this runs
+first.
+
+Values are assigned rather than defaulted: a developer with a populated `.env`
+would otherwise hand real credentials to the suite, and `load_dotenv()` in
+`app.main` pulls that file into the process environment.
+"""
+
+import os
+
+os.environ["DATABASE_URL"] = "postgresql://test:test@localhost:5432/agents_test"
+os.environ["OPENAI_API_KEY"] = "sk-test-not-a-real-key"
+os.environ["REDIS_URL"] = "redis://localhost:6379/15"
+os.environ["API_KEY_SECRET"] = "test-secret"
+os.environ["ENVIRONMENT"] = "test"
+
+# Every third-party key the app reads, blanked so a misconfigured test cannot
+# authenticate against a real service even if it somehow escapes the guard below.
+for _key in (
+    "ALUMNI_EXTRACT_API_KEY",
+    "BRIGHTDATA_API_KEY",
+    "CLOUDINARY_API_KEY",
+    "CLOUDINARY_API_SECRET",
+    "GEOLOCATION_API_KEY",
+):
+    os.environ[_key] = ""
+
+import socket  # noqa: E402
+
+import pytest  # noqa: E402
+
+# Loopback stays open so tests can reach a Postgres/Redis service container.
+# Everything else is refused.
+_ALLOWED_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "0.0.0.0"})
+
+_real_connect = socket.socket.connect
+_real_connect_ex = socket.socket.connect_ex
+_real_create_connection = socket.create_connection
+
+
+class NetworkAccessAttempted(RuntimeError):
+    """A test tried to open a non-loopback connection."""
+
+
+def _describe(address: object) -> str:
+    if isinstance(address, tuple) and address:
+        return f"{address[0]}:{address[1] if len(address) > 1 else '?'}"
+    return str(address)
+
+
+def _is_allowed(address: object) -> bool:
+    # AF_UNIX addresses are plain strings and never leave the machine.
+    if isinstance(address, (str, bytes)):
+        return True
+    if isinstance(address, tuple) and address:
+        return address[0] in _ALLOWED_HOSTS
+    return False
+
+
+def _refuse(address: object) -> NetworkAccessAttempted:
+    return NetworkAccessAttempted(
+        f"Blocked outbound connection to {_describe(address)}.\n"
+        "Tests must not touch the network — a live LLM or enrichment call is billed "
+        "on every CI run. Stub the client, or use the `respx_mock` fixture for httpx.\n"
+        "If this is a legitimate local service, add its host to _ALLOWED_HOSTS."
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def block_network() -> None:
+    """Refuse non-loopback connections for the whole session.
+
+    Enforced rather than documented: the cost of a test quietly calling a paid
+    API is real money on every push, and a convention does not stop it.
+    """
+
+    def guarded_connect(self, address):  # type: ignore[no-untyped-def]
+        if not _is_allowed(address):
+            raise _refuse(address)
+        return _real_connect(self, address)
+
+    def guarded_connect_ex(self, address):  # type: ignore[no-untyped-def]
+        if not _is_allowed(address):
+            raise _refuse(address)
+        return _real_connect_ex(self, address)
+
+    def guarded_create_connection(address, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if not _is_allowed(address):
+            raise _refuse(address)
+        return _real_create_connection(address, *args, **kwargs)
+
+    socket.socket.connect = guarded_connect
+    socket.socket.connect_ex = guarded_connect_ex
+    socket.create_connection = guarded_create_connection
+    try:
+        yield
+    finally:
+        socket.socket.connect = _real_connect
+        socket.socket.connect_ex = _real_connect_ex
+        socket.create_connection = _real_create_connection
+
+
+@pytest.fixture
+def allow_loopback_check():
+    """Expose the guard's predicate so tests can assert on it directly."""
+    return _is_allowed

--- a/agents-api/tests/test_esco_reference.py
+++ b/agents-api/tests/test_esco_reference.py
@@ -1,0 +1,93 @@
+"""Tests for ESCO reranking.
+
+The reranker is the step CAR-106 wants to improve, so pinning its contract now
+gives that work a baseline to measure against.
+"""
+
+import pytest
+
+from app.schemas.job_classification import EscoResult
+from app.utils.agents import esco_reference
+
+
+class StubCrossEncoder:
+    """Returns scores by lookup on the candidate title, in call order."""
+
+    def __init__(self, scores_by_title):
+        self._scores = scores_by_title
+        self.pairs_seen = None
+
+    def predict(self, pairs):
+        self.pairs_seen = pairs
+        return [self._scores[title] for _query, title in pairs]
+
+
+@pytest.fixture
+def results():
+    return [
+        EscoResult(id="1", title="Software developer", confidence=0.70),
+        EscoResult(id="2", title="Systems analyst", confidence=0.90),
+        EscoResult(id="3", title="Data entry clerk", confidence=0.50),
+    ]
+
+
+@pytest.fixture
+def stub_encoder(monkeypatch):
+    def _install(scores_by_title):
+        stub = StubCrossEncoder(scores_by_title)
+        monkeypatch.setattr(esco_reference, "get_cross_encoder", lambda: stub)
+        return stub
+
+    return _install
+
+
+def test_reorders_by_cross_encoder_score(stub_encoder, results):
+    """The reranker's whole purpose: override embedding order with its own."""
+    stub_encoder({"Software developer": 9.0, "Systems analyst": 1.0, "Data entry clerk": 5.0})
+
+    ranked = esco_reference.rerank_esco("backend engineer", results)
+
+    assert [r.title for r in ranked] == [
+        "Software developer",
+        "Data entry clerk",
+        "Systems analyst",
+    ]
+
+
+def test_truncates_to_top_k(stub_encoder, results):
+    stub_encoder({"Software developer": 9.0, "Systems analyst": 1.0, "Data entry clerk": 5.0})
+
+    ranked = esco_reference.rerank_esco("backend engineer", results, top_k=2)
+
+    assert [r.title for r in ranked] == ["Software developer", "Data entry clerk"]
+
+
+def test_pairs_each_candidate_with_the_query(stub_encoder, results):
+    stub = stub_encoder(
+        {"Software developer": 1.0, "Systems analyst": 1.0, "Data entry clerk": 1.0}
+    )
+
+    esco_reference.rerank_esco("backend engineer", results)
+
+    assert stub.pairs_seen == [
+        ["backend engineer", "Software developer"],
+        ["backend engineer", "Systems analyst"],
+        ["backend engineer", "Data entry clerk"],
+    ]
+
+
+def test_empty_candidate_list_is_handled(stub_encoder):
+    stub_encoder({})
+
+    assert esco_reference.rerank_esco("backend engineer", []) == []
+
+
+def test_cross_encoder_is_not_loaded_at_import():
+    """Regression guard for the lazy-loading fix.
+
+    Constructing the CrossEncoder reaches HuggingFace Hub on a cold cache, so a
+    module-scope instance made this module unimportable without network access —
+    and with it app.main. Keep the load behind the accessor.
+    """
+    esco_reference.get_cross_encoder.cache_clear()
+    assert esco_reference.get_cross_encoder.cache_info().currsize == 0

--- a/agents-api/tests/test_job_classification_agent.py
+++ b/agents-api/tests/test_job_classification_agent.py
@@ -1,0 +1,261 @@
+"""Behavioural tests for the job classification agent.
+
+Pins the embedding-lookup and LLM-validation steps before CAR-103 rewrites the
+agents onto Pydantic AI, and before CAR-106/CAR-108 change what gets sent to the
+model. Redis and the model client are both stubbed — neither is reachable.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from app.agents.job_classification import JobClassificationAgent, get_esco_prompt
+from app.schemas.job_classification import (
+    EscoResult,
+    JobClassificationAgentState,
+    JobClassificationRoleInput,
+)
+from app.utils.prompts import VALIDATE_ESCO_CORE_PROMPT, VALIDATE_ESCO_EXTRA_DETAILS
+
+
+class StubResponse:
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+        self.content = ""
+
+
+class StubLLM:
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+
+    async def ainvoke(self, messages):
+        self.calls.append(messages)
+        return self._response
+
+
+class FakeRedis:
+    """In-memory stand-in for the agent's Redis cache."""
+
+    def __init__(self):
+        self.store = {}
+        self.setex_calls = []
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, ttl, value):
+        self.setex_calls.append((key, ttl, value))
+        self.store[key] = value
+
+
+@pytest.fixture
+def agent():
+    a = JobClassificationAgent()
+    a._redis_cache = FakeRedis()
+    return a
+
+
+@pytest.fixture
+def role():
+    return JobClassificationRoleInput(
+        role_id="role-1",
+        title="Backend Engineer",
+        description=None,
+        start_date=datetime(2021, 9, 1),
+        end_date=None,
+        company_name="Feup Systems",
+        industry_name="Software",
+        is_promotion=False,
+    )
+
+
+@pytest.fixture
+def state(role):
+    """Mirrors the state `_process_roles_batch` builds."""
+    return JobClassificationAgentState(
+        role=role,
+        messages=[],
+        esco_results_from_embeddings=[],
+        esco_results_from_agent=[],
+        parsed_esco_results=[],
+        processing_time=0.0,
+        model_used="gpt-4o-mini",
+        retry_count=0,
+        error=None,
+        reasoning=None,
+    )
+
+
+# --- prompt selection ---------------------------------------------------------
+
+
+def test_first_attempt_uses_the_core_prompt_only():
+    assert get_esco_prompt(0) == VALIDATE_ESCO_CORE_PROMPT
+
+
+def test_retries_append_the_extra_guidance():
+    """Retries widen the prompt — that escalation is the point of the retry."""
+    prompt = get_esco_prompt(1)
+
+    assert VALIDATE_ESCO_CORE_PROMPT in prompt
+    assert VALIDATE_ESCO_EXTRA_DETAILS in prompt
+
+
+# --- embedding lookup ---------------------------------------------------------
+
+
+def test_search_query_is_the_title_when_there_is_no_description(monkeypatch, agent, state):
+    seen = []
+    monkeypatch.setattr(
+        "app.agents.job_classification.search_esco_classifications",
+        lambda q: seen.append(q) or [],
+    )
+
+    agent.get_best_esco_matches_db(state)
+
+    assert seen == ["Backend Engineer"]
+
+
+def test_description_is_appended_to_the_search_query(monkeypatch, agent, state):
+    state["role"].description = "Builds APIs and services"
+    seen = []
+    monkeypatch.setattr(
+        "app.agents.job_classification.search_esco_classifications",
+        lambda q: seen.append(q) or [],
+    )
+
+    agent.get_best_esco_matches_db(state)
+
+    assert seen == ["Backend Engineer Builds APIs and services"]
+
+
+def test_cache_hit_skips_the_vector_search(monkeypatch, agent, state):
+    """The cache exists to avoid paying for embeddings twice."""
+    cached = [{"id": "1", "title": "Software developer", "confidence": 0.9}]
+    agent._set_in_cache("Backend Engineer", cached)
+
+    def fail(_query):
+        raise AssertionError("vector search ran despite a cache hit")
+
+    monkeypatch.setattr("app.agents.job_classification.search_esco_classifications", fail)
+
+    out = agent.get_best_esco_matches_db(state)
+
+    assert out["esco_results_from_embeddings"] == cached
+
+
+def test_results_are_cached_on_a_miss(monkeypatch, agent, state):
+    results = [EscoResult(id="1", title="Software developer", confidence=0.9)]
+    monkeypatch.setattr(
+        "app.agents.job_classification.search_esco_classifications", lambda _q: results
+    )
+
+    agent.get_best_esco_matches_db(state)
+
+    assert len(agent._redis_cache.setex_calls) == 1
+    key, ttl, _value = agent._redis_cache.setex_calls[0]
+    assert key == "esco_classification:Backend Engineer"
+    assert ttl == agent.CACHE_TTL
+
+
+def test_empty_results_are_not_cached(monkeypatch, agent, state):
+    """Caching an empty result would pin the miss for 24 hours."""
+    monkeypatch.setattr("app.agents.job_classification.search_esco_classifications", lambda _q: [])
+
+    agent.get_best_esco_matches_db(state)
+
+    assert agent._redis_cache.setex_calls == []
+
+
+def test_search_failure_is_recorded_and_does_not_propagate(monkeypatch, agent, state):
+    """One role failing to classify must not abort the surrounding batch."""
+
+    def boom(_query):
+        raise RuntimeError("pgvector connection lost")
+
+    monkeypatch.setattr("app.agents.job_classification.search_esco_classifications", boom)
+
+    out = agent.get_best_esco_matches_db(state)
+
+    assert out["esco_results_from_embeddings"] == []
+    assert "pgvector connection lost" in out["error"]
+
+
+# --- LLM validation -----------------------------------------------------------
+
+
+def _esco_tool_call(results, reasoning="Closest ESCO match for a backend role."):
+    return {
+        "name": "return_esco_choices",
+        "args": {"results": results, "reasoning": reasoning},
+    }
+
+
+async def test_parses_results_and_reasoning_from_the_tool_call(monkeypatch, agent, state):
+    results = [{"id": "1", "title": "Software developer", "confidence": 0.93}]
+    stub = StubLLM(StubResponse([_esco_tool_call(results)]))
+    monkeypatch.setattr("app.agents.job_classification.llm_with_tools", stub)
+
+    out = await agent.validate_esco_results_batch([state])
+
+    assert out[0]["parsed_esco_results"] == results
+    assert out[0]["reasoning"] == "Closest ESCO match for a backend role."
+
+
+async def test_missing_reasoning_falls_back_to_a_placeholder(monkeypatch, agent, state):
+    tool_call = {"name": "return_esco_choices", "args": {"results": []}}
+    monkeypatch.setattr(
+        "app.agents.job_classification.llm_with_tools", StubLLM(StubResponse([tool_call]))
+    )
+
+    out = await agent.validate_esco_results_batch([state])
+
+    assert out[0]["reasoning"] == "No explanation provided."
+
+
+async def test_embedding_candidates_are_sent_to_the_model(monkeypatch, agent, state):
+    """The model's job is to *validate* the shortlist, so it must receive it."""
+    state["esco_results_from_embeddings"] = [
+        EscoResult(id="42", title="Systems analyst", confidence=0.81)
+    ]
+    stub = StubLLM(StubResponse([_esco_tool_call([])]))
+    monkeypatch.setattr("app.agents.job_classification.llm_with_tools", stub)
+
+    await agent.validate_esco_results_batch([state])
+
+    prompt = "\n".join(m.content for m in stub.calls[0])
+    assert "Systems analyst" in prompt
+    assert "Backend Engineer" in prompt
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known bug, same shape as the one in seniority.classify_seniority: when the "
+        "model returns no `return_esco_choices` tool call, _validate_single falls off "
+        "the end and implicitly returns None, so asyncio.gather collects None into the "
+        "results list and batch_update_classifications then raises on None['role']. "
+        "location.resolve_geo gets this right — it returns state outside the branch. "
+        "Fix during CAR-103; this test will start passing then."
+    ),
+)
+async def test_missing_tool_call_still_returns_the_state(monkeypatch, agent, state):
+    stub = StubLLM(StubResponse([{"name": "some_other_tool", "args": {}}]))
+    monkeypatch.setattr("app.agents.job_classification.llm_with_tools", stub)
+
+    out = await agent.validate_esco_results_batch([state])
+
+    assert out[0] is not None
+
+
+async def test_batches_are_processed_together(monkeypatch, agent, state, role):
+    """Up to three roles go in one chunk; a fourth would trigger a 5s sleep."""
+    stub = StubLLM(StubResponse([_esco_tool_call([])]))
+    monkeypatch.setattr("app.agents.job_classification.llm_with_tools", stub)
+    states = [dict(state), dict(state), dict(state)]
+
+    out = await agent.validate_esco_results_batch(states)
+
+    assert len(out) == 3
+    assert len(stub.calls) == 3

--- a/agents-api/tests/test_location_agent.py
+++ b/agents-api/tests/test_location_agent.py
@@ -1,0 +1,282 @@
+"""Behavioural tests for the location agent.
+
+Covers cache keying, prompt assembly per input type, and geo resolution. Redis,
+the token rate limiter, the tokenizer and the model client are all stubbed —
+none of them are reachable from a test.
+
+Relevant to CAR-117 (location alias normalisation), which will change how inputs
+map onto resolved locations; these pin the current contract first.
+"""
+
+import json
+
+import pytest
+
+from app.agents.location import LocationAgent
+from app.schemas.location import (
+    AlumniLocationInput,
+    CompanyLocationInput,
+    LocationAgentState,
+    LocationResult,
+    RoleLocationInput,
+)
+
+
+class StubResponse:
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+        self.content = ""
+
+
+class StubLLM:
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+
+    async def ainvoke(self, messages):
+        self.calls.append(messages)
+        return self._response
+
+
+class StubRateLimiter:
+    """Records the token budget requested, without touching Redis."""
+
+    def __init__(self):
+        self.acquired = []
+
+    async def acquire(self, tokens):
+        self.acquired.append(tokens)
+
+
+class StubEncoding:
+    """One token per whitespace-separated word — enough to exercise the count."""
+
+    def encode(self, text):
+        return text.split()
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, _ttl, value):
+        self.store[key] = value
+
+
+@pytest.fixture
+def agent():
+    a = LocationAgent()
+    a._redis_cache = FakeRedis()
+    return a
+
+
+@pytest.fixture
+def company_input():
+    return CompanyLocationInput(
+        company_id="company-1", headquarters="Porto, Portugal", country_codes="PT,ES"
+    )
+
+
+@pytest.fixture
+def role_input():
+    return RoleLocationInput(role_id="role-1", location="Porto Metropolitan Area")
+
+
+@pytest.fixture
+def alumni_input():
+    return AlumniLocationInput(
+        alumni_id="alumni-1", city="Porto", country="Portugal", country_code="PT"
+    )
+
+
+@pytest.fixture
+def stub_geo(monkeypatch):
+    """Replace everything resolve_geo reaches for outside the process."""
+
+    def _install(tool_calls):
+        llm = StubLLM(StubResponse(tool_calls))
+        limiter = StubRateLimiter()
+        monkeypatch.setattr("app.agents.location.llm_with_tools", llm)
+        monkeypatch.setattr("app.agents.location.rate_limiter", limiter)
+        monkeypatch.setattr("app.agents.location.get_encoding", lambda: StubEncoding())
+        return llm, limiter
+
+    return _install
+
+
+def _state(location_input):
+    return LocationAgentState(
+        input=location_input,
+        type=location_input.type,
+        messages=[],
+        resolved_country_code=None,
+        resolved_city=None,
+        db_locations=[],
+        location_result=None,
+        processing_time=0.0,
+        model_used="gpt-4o-mini",
+    )
+
+
+# --- cache keys ---------------------------------------------------------------
+
+
+def test_cache_key_is_namespaced_per_input_type(agent, company_input, role_input, alumni_input):
+    """Distinct namespaces stop a role and a company sharing a cache entry."""
+    assert agent._get_cache_key(company_input) == "location:company:Porto, Portugal"
+    assert agent._get_cache_key(role_input) == "location:role:Porto Metropolitan Area"
+    assert agent._get_cache_key(alumni_input) == "location:alumni:Porto:Portugal"
+
+
+def test_cached_result_round_trips(agent, role_input):
+    result = LocationResult(
+        id="loc-1",
+        country_code="PT",
+        country="Portugal",
+        is_country_only=False,
+        city="Porto",
+    )
+    agent._set_in_cache(role_input, result)
+
+    assert agent._get_from_cache(role_input) == result
+
+
+def test_cache_miss_returns_none(agent, role_input):
+    assert agent._get_from_cache(role_input) is None
+
+
+def test_cached_payload_is_json(agent, role_input):
+    """Stored as JSON so it survives a restart and stays inspectable in Redis."""
+    result = LocationResult(
+        id=None, country_code="PT", country="Portugal", is_country_only=True, city=None
+    )
+    agent._set_in_cache(role_input, result)
+
+    raw = agent._redis_cache.store["location:role:Porto Metropolitan Area"]
+    assert json.loads(raw)["country_code"] == "PT"
+
+
+# --- prompt assembly ----------------------------------------------------------
+
+
+def test_company_details_include_headquarters_and_country_codes(agent, company_input):
+    details = agent._build_input_details(company_input)
+
+    assert "Porto, Portugal" in details
+    assert "PT,ES" in details
+
+
+def test_role_details_include_the_free_text_location(agent, role_input):
+    assert "Porto Metropolitan Area" in agent._build_input_details(role_input)
+
+
+def test_alumni_details_include_city_country_and_code(agent, alumni_input):
+    details = agent._build_input_details(alumni_input)
+
+    assert "Porto" in details
+    assert "Portugal" in details
+    assert "PT" in details
+
+
+# --- geo resolution -----------------------------------------------------------
+
+
+def _geo_tool_call(country_code="PT", city="Porto"):
+    return {
+        "name": "return_geo_resolution",
+        "args": {"country_code": country_code, "city": city},
+    }
+
+
+async def test_resolves_country_code_and_city_from_the_tool_call(agent, stub_geo, role_input):
+    stub_geo([_geo_tool_call()])
+
+    out = await agent.resolve_geo(_state(role_input))
+
+    assert out["resolved_country_code"] == "PT"
+    assert out["resolved_city"] == "Porto"
+
+
+async def test_remote_locations_resolve_without_a_city(agent, stub_geo, role_input):
+    """'Remote' has a country code sentinel and no city — a documented case."""
+    stub_geo([_geo_tool_call(country_code="REMOTE", city=None)])
+
+    out = await agent.resolve_geo(_state(role_input))
+
+    assert out["resolved_country_code"] == "REMOTE"
+    assert out["resolved_city"] is None
+
+
+async def test_missing_tool_call_records_an_error_and_still_returns_state(
+    agent, stub_geo, role_input
+):
+    """Unlike the other two agents, this one returns state on the failure path."""
+    stub_geo([{"name": "some_other_tool", "args": {}}])
+
+    out = await agent.resolve_geo(_state(role_input))
+
+    assert out is not None
+    assert out["error"] == "Failed to get tool call from LLM response"
+
+
+async def test_location_details_reach_the_model(agent, stub_geo, company_input):
+    llm, _limiter = stub_geo([_geo_tool_call()])
+
+    await agent.resolve_geo(_state(company_input))
+
+    prompt = "\n".join(m.content for m in llm.calls[0])
+    assert "Porto, Portugal" in prompt
+    assert "PT,ES" in prompt
+
+
+async def test_token_budget_is_reserved_before_the_model_call(agent, stub_geo, role_input):
+    """Rate limiting is the guard against blowing the 200k tokens/minute cap."""
+    _llm, limiter = stub_geo([_geo_tool_call()])
+
+    await agent.resolve_geo(_state(role_input))
+
+    assert len(limiter.acquired) == 1
+    # Estimate plus the 100-token buffer the agent adds.
+    assert limiter.acquired[0] > 100
+
+
+async def test_response_is_appended_to_message_history(agent, stub_geo, role_input):
+    llm, _limiter = stub_geo([_geo_tool_call()])
+
+    out = await agent.resolve_geo(_state(role_input))
+
+    assert llm._response in out["messages"]
+
+
+async def test_model_failure_is_recorded_and_re_raised(agent, monkeypatch, role_input):
+    """Geo resolution is the first stage — failing loudly beats a silent bad location."""
+
+    class ExplodingLLM:
+        async def ainvoke(self, _messages):
+            raise RuntimeError("upstream unavailable")
+
+    monkeypatch.setattr("app.agents.location.llm_with_tools", ExplodingLLM())
+    monkeypatch.setattr("app.agents.location.rate_limiter", StubRateLimiter())
+    monkeypatch.setattr("app.agents.location.get_encoding", lambda: StubEncoding())
+    state = _state(role_input)
+
+    with pytest.raises(RuntimeError, match="upstream unavailable"):
+        await agent.resolve_geo(state)
+
+    assert state["error"] == "upstream unavailable"
+
+
+def test_tokenizer_is_not_resolved_at_import():
+    """Regression guard for the lazy-loading fix.
+
+    tiktoken downloads its BPE vocabulary on a cold cache, so resolving the
+    encoding at module scope made this module — and app.main — unimportable
+    without network access.
+    """
+    from app.agents import location
+
+    location.get_encoding.cache_clear()
+    assert location.get_encoding.cache_info().currsize == 0

--- a/agents-api/tests/test_network_guard.py
+++ b/agents-api/tests/test_network_guard.py
@@ -1,0 +1,42 @@
+"""The guard is the suite's cost control, so it gets its own tests.
+
+If these regress, a test making a paid LLM call would pass silently and bill on
+every CI run — the failure this whole arrangement exists to prevent.
+"""
+
+import socket
+
+import pytest
+
+from tests.conftest import NetworkAccessAttempted
+
+
+def test_outbound_connection_is_refused():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    with pytest.raises(NetworkAccessAttempted):
+        sock.connect(("api.openai.com", 443))
+
+
+def test_create_connection_is_refused():
+    with pytest.raises(NetworkAccessAttempted):
+        socket.create_connection(("huggingface.co", 443))
+
+
+def test_refusal_names_the_host():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    with pytest.raises(NetworkAccessAttempted, match="api.anthropic.com:443"):
+        sock.connect(("api.anthropic.com", 443))
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_loopback_is_permitted(allow_loopback_check, host):
+    """Local Postgres/Redis service containers must stay reachable."""
+    assert allow_loopback_check((host, 5432))
+
+
+def test_unix_sockets_are_permitted(allow_loopback_check):
+    assert allow_loopback_check("/var/run/postgresql/.s.PGSQL.5432")
+
+
+def test_external_host_is_not_permitted(allow_loopback_check):
+    assert not allow_loopback_check(("169.254.169.254", 80))

--- a/agents-api/tests/test_network_guard.py
+++ b/agents-api/tests/test_network_guard.py
@@ -12,9 +12,9 @@ from tests.conftest import NetworkAccessAttempted
 
 
 def test_outbound_connection_is_refused():
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    with pytest.raises(NetworkAccessAttempted):
-        sock.connect(("api.openai.com", 443))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        with pytest.raises(NetworkAccessAttempted):
+            sock.connect(("api.openai.com", 443))
 
 
 def test_create_connection_is_refused():
@@ -23,9 +23,9 @@ def test_create_connection_is_refused():
 
 
 def test_refusal_names_the_host():
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    with pytest.raises(NetworkAccessAttempted, match="api.anthropic.com:443"):
-        sock.connect(("api.anthropic.com", 443))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        with pytest.raises(NetworkAccessAttempted, match="api.anthropic.com:443"):
+            sock.connect(("api.anthropic.com", 443))
 
 
 @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])

--- a/agents-api/tests/test_seniority_agent.py
+++ b/agents-api/tests/test_seniority_agent.py
@@ -1,0 +1,138 @@
+"""Behavioural tests for the seniority agent.
+
+These exist to pin current behaviour before CAR-103 rewrites all three agents
+onto Pydantic AI. They assert on prompt construction and response parsing — the
+two things a framework migration is most likely to change silently.
+"""
+
+import pytest
+
+from app.agents.seniority import SeniorityAgent
+from app.schemas.seniority import BatchSeniorityInput, RoleSeniorityInput, SeniorityAgentState
+
+
+class StubResponse:
+    """Stands in for a LangChain AIMessage carrying tool calls."""
+
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+        self.content = ""
+
+
+class StubLLM:
+    """Records the messages it was invoked with, returns a canned response."""
+
+    def __init__(self, response):
+        self._response = response
+        self.calls = []
+
+    def invoke(self, messages):
+        self.calls.append(messages)
+        return self._response
+
+
+@pytest.fixture
+def batch():
+    return BatchSeniorityInput(
+        alumni_id="alumni-1",
+        roles=[
+            RoleSeniorityInput(
+                role_id="role-1",
+                title="Staff Software Engineer",
+                company="Feup Systems",
+                duration="3 years",
+                start_date="2021-09-01",
+                end_date=None,
+                is_current=True,
+            )
+        ],
+        total_experience="8 years",
+        industries=["Software"],
+        companies=["Feup Systems"],
+    )
+
+
+@pytest.fixture
+def state(batch):
+    """Mirrors the state `SeniorityAgent.process_role_batch` builds."""
+    return SeniorityAgentState(
+        batch=batch,
+        messages=[],
+        seniority_results_from_agent=None,
+        parsed_seniority_results=[],
+        processing_time=0.0,
+        model_used="gpt-4o-mini",
+        retry_count=0,
+        error=None,
+    )
+
+
+def _tool_call(results):
+    return {"name": "return_seniority_choices", "args": {"results": results}}
+
+
+def test_parses_results_from_the_tool_call(monkeypatch, state):
+    results = [
+        {
+            "role_id": "role-1",
+            "seniority": "MID_SENIOR_LEVEL",
+            "confidence": 0.91,
+            "reasoning": "Staff title with 8 years of experience.",
+        }
+    ]
+    stub = StubLLM(StubResponse([_tool_call(results)]))
+    monkeypatch.setattr("app.agents.seniority.llm_with_tools", stub)
+
+    out = SeniorityAgent().classify_seniority(state)
+
+    assert out["parsed_seniority_results"] == results
+
+
+def test_sends_role_context_to_the_model(monkeypatch, state):
+    stub = StubLLM(StubResponse([_tool_call([])]))
+    monkeypatch.setattr("app.agents.seniority.llm_with_tools", stub)
+
+    SeniorityAgent().classify_seniority(state)
+
+    assert len(stub.calls) == 1
+    prompt = "\n".join(m.content for m in stub.calls[0])
+    # The model cannot judge seniority without the title, employer, and tenure.
+    assert "Staff Software Engineer" in prompt
+    assert "Feup Systems" in prompt
+    assert "8 years" in prompt
+
+
+def test_open_ended_role_is_described_as_present(monkeypatch, state):
+    stub = StubLLM(StubResponse([_tool_call([])]))
+    monkeypatch.setattr("app.agents.seniority.llm_with_tools", stub)
+
+    SeniorityAgent().classify_seniority(state)
+
+    assert "Present" in "\n".join(m.content for m in stub.calls[0])
+
+
+def test_appends_the_response_to_message_history(monkeypatch, state):
+    response = StubResponse([_tool_call([])])
+    monkeypatch.setattr("app.agents.seniority.llm_with_tools", StubLLM(response))
+
+    out = SeniorityAgent().classify_seniority(state)
+
+    assert response in out["messages"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known bug: when the model returns no `return_seniority_choices` tool call, "
+        "classify_seniority falls off the end and implicitly returns None instead of "
+        "the state. Downstream nodes then receive None. Should return the unchanged "
+        "state (or raise). Fix during CAR-103; this test will start passing then."
+    ),
+)
+def test_missing_tool_call_still_returns_the_state(monkeypatch, state):
+    stub = StubLLM(StubResponse([{"name": "some_other_tool", "args": {}}]))
+    monkeypatch.setattr("app.agents.seniority.llm_with_tools", stub)
+
+    out = SeniorityAgent().classify_seniority(state)
+
+    assert out is not None

--- a/agents-api/uv.lock
+++ b/agents-api/uv.lock
@@ -39,15 +39,13 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
-    { name = "ruff" },
-]
-
-[package.dev-dependencies]
-dev = [
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -64,7 +62,6 @@ requires-dist = [
     { name = "langchain-ollama", specifier = ">=0.0.1" },
     { name = "langchain-openai", specifier = ">=0.3.18" },
     { name = "langgraph", specifier = ">=0.0.20" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "openai", specifier = ">=1.73.0" },
     { name = "pandas", specifier = ">=2.2.0" },
@@ -73,20 +70,24 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.22.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "pydantic", specifier = ">=2.6.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "redis", specifier = ">=6.1.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "sentence-transformers", specifier = ">=4.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
     { name = "transformers", specifier = ">=4.52.3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.11.4" }]
+dev = [
+    { name = "mypy", specifier = ">=1.8.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "respx", specifier = ">=0.21.0" },
+    { name = "ruff", specifier = ">=0.11.4" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -313,6 +314,105 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/c3/4f2195f512fb172aa425a8803a874b2baa9ba7f80ff7b6080998761fc701/coverage-7.15.4.tar.gz", hash = "sha256:0548198fff07ccf4faf469520bce1c2eceb1ce3e62891921138dec10907f9d00", size = 936952 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/48/bc8d4ba7b37551a767bd863f15b3f80182b271c2f55975356f5f7dbe94c2/coverage-7.15.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4fedd1f7f428f9fe83b1ead5e7cc87a43427be31aadafbac3ac0636dc7abb22", size = 222543 },
+    { url = "https://files.pythonhosted.org/packages/20/dd/88d6f83f1fffc974a3691a34a97951c5b12df7512a6782c5963883cbc058/coverage-7.15.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:37e2f0cdf58e2e1fed4e4d5a8f8786ae2f7eb80b478016876667dc4a01d60a97", size = 222905 },
+    { url = "https://files.pythonhosted.org/packages/bd/5c/54ee0d4748585bb0acab9891cd8d92f2d3593165b4e59fc9de113bfb3140/coverage-7.15.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fb55d0e70bb15f2e81477613627286581414693d74ac7963c93a790dd453ca9d", size = 254407 },
+    { url = "https://files.pythonhosted.org/packages/8c/3f/f0642a372f494bd0d7dad3b497083b910194a5f1c88be2c94fef707c3b59/coverage-7.15.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:899b9da30f3c6c336566e3707495bb23e8302d39d862f01fa78c48b99b9437e2", size = 257145 },
+    { url = "https://files.pythonhosted.org/packages/71/17/8b46d0ed68251016002ec972c8fc0119961a765d0984cafb8bf317c43758/coverage-7.15.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d15715e8c46552827e5e4f30a35575a2dbcad14454cf3284c54483946bd16931", size = 258257 },
+    { url = "https://files.pythonhosted.org/packages/30/b8/8498a0e72d0adbe15477dd07463d2b3bb2c9f6a4815e8589e50939e2c3ae/coverage-7.15.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:002a438859f7b430bc99afeaf01a6d187dad1d0dc907b64cdeffc632a5db8fd8", size = 260517 },
+    { url = "https://files.pythonhosted.org/packages/41/e1/7dce19c3bdb1e3dd63e769508216500edad81bd5f69a26d724e32aceaf78/coverage-7.15.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4193a04b518f7968f3099755f5509ee7cccc6dc2b92a6b14841934d22e222c9", size = 254785 },
+    { url = "https://files.pythonhosted.org/packages/dd/b1/e1494703c675a2561723cd9b89f45c9168782c31280c611b1f767851e57c/coverage-7.15.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e98dcc55d572b38e69d117da7e8e8efb8500f1f5eaf81ecd460a63220790b839", size = 256176 },
+    { url = "https://files.pythonhosted.org/packages/73/76/a5629d270fb638a43a4b10466f51e2f49d532c1aa4da2913cbbb150bbe0a/coverage-7.15.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:af6c538498ce66c10d3fd541c2a8d5b03da5850355add34e6cba564210cb9e72", size = 254321 },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/9c44447218435d5766b911534f9d798144a5560f85e9a54ebe5f3f5d19f9/coverage-7.15.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1d10025d96ea89fc2f73714dbc4cbd433fe012c1ac9e23f895d7728b238b6e52", size = 258390 },
+    { url = "https://files.pythonhosted.org/packages/de/36/c1e127616fb3fa18a9ff71e76c417f2fd7424332a4870015ac224ef4c039/coverage-7.15.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d802e1947603162ded419bff83ac7489820355d2b856dfb09206574e3a37ac0c", size = 253894 },
+    { url = "https://files.pythonhosted.org/packages/e9/b9/fdb92c8ae7a8bb9b850cc253b7b3b9c8526f68130002048b5671cd510d09/coverage-7.15.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c2de40895718f91951b86712b4c5b694acaf9a0a49be13874896f599a1eed3f4", size = 255763 },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/a7d51b2587c7bdb76e71b0896d2565bf7d60436b5122fc83e511adb1f7cd/coverage-7.15.4-cp312-cp312-win32.whl", hash = "sha256:5c3431b2161279b7db5c2a1aa58ae02e5cb8c3c42d93a5094be3f5537bd5b11b", size = 224597 },
+    { url = "https://files.pythonhosted.org/packages/49/b9/5c5f80cc55f5acaaca6dee677626bfcec8c87204a7809b438b08e84f4571/coverage-7.15.4-cp312-cp312-win_amd64.whl", hash = "sha256:6befeab5fb2b51c958ca4ac6c5d141a1e8240f4f76e46350f1911963deda49cd", size = 225135 },
+    { url = "https://files.pythonhosted.org/packages/47/e4/2a4561f89ff6bf7c925c287d0f2cce8bdf139c3a33735c87e3203401cf94/coverage-7.15.4-cp312-cp312-win_arm64.whl", hash = "sha256:67bc345491ab55b837277d76f5775d057e8c7f1ac44d890d8c2c82adde258c6f", size = 224515 },
+    { url = "https://files.pythonhosted.org/packages/f1/84/651a9310859673aaa3b3203f1aa1641ca60fcf2494683e1c9474c7172780/coverage-7.15.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c705b28feb2775dc82a25f1d473a370bc37ff93f5177f4e29ce2425f560f6921", size = 222565 },
+    { url = "https://files.pythonhosted.org/packages/82/f9/4dcf700137e8af550670f4d74d1b63828ce93e1e2b05e5f10710eb2ea987/coverage-7.15.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3ff205ab5e3ecc670f6a4dd19d9cbf12ede53dd41cfc1e15716ec961ea6d314e", size = 222936 },
+    { url = "https://files.pythonhosted.org/packages/07/4a/612ff1e780b3fbfd637486f542f84adc5503873d8b5d279dec1ffeef9414/coverage-7.15.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5172326e861a38b48b48befca15e0f477a26b283337a33a739c8fed229934e36", size = 253926 },
+    { url = "https://files.pythonhosted.org/packages/b0/04/d1cff1c2ead4708a6a79c01d3736b6a25bd38a36678398f72a8dd33dfad9/coverage-7.15.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:12b59c90084e3234fb11184886bf4a40f4f16a8c8f867be2e087b81f8e8868d4", size = 256523 },
+    { url = "https://files.pythonhosted.org/packages/b9/80/d34e13fb4b293cbdb9665838cf5522077b8ad14ef947550631a4bced36a5/coverage-7.15.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349062d66f00b40fa2c1c222438bad25fabf755631b5d82937fe985c8008615c", size = 257759 },
+    { url = "https://files.pythonhosted.org/packages/0f/e7/2c5fe7636fdb0732fe0f09f308a5b066864078b7fc61f6678e8478554f2e/coverage-7.15.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4256ced708e598e05209bc1a8ab4074e04a51dba4c62fb45926a229af675ace7", size = 259890 },
+    { url = "https://files.pythonhosted.org/packages/92/28/9689f0858dfff59c2ea688938ab9fa2925631235df67126a42b6c5c70ae1/coverage-7.15.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d80f974b20782d9612c8b4c9beeca867074c7cf4079d1419843fa25a26428b25", size = 254121 },
+    { url = "https://files.pythonhosted.org/packages/f9/e2/785077c230c157243eb5aa9a26c3be260ecd02001bead54a3cada3df8e03/coverage-7.15.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e179f19bfe1d31f8eeeaa12990194d761c4f62f0759661000bca6cd8729f40b", size = 255891 },
+    { url = "https://files.pythonhosted.org/packages/d4/90/e20371b17b40f912f21305c2db2f30efa3de306f7320fc916804872c85a4/coverage-7.15.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8bc16bb47b7679670eceff71d78bfb7d6e5b143f6c2cd117487ec7c75e0d4b78", size = 253859 },
+    { url = "https://files.pythonhosted.org/packages/05/49/25371987ee459a5f67c0427fb75c74f9358e65f2c71fe75bf41c1b6c5fcb/coverage-7.15.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd685005cd2c4200adfc14cf39a603b9320efab3f18a8f7f156d20c9cc3345f", size = 258011 },
+    { url = "https://files.pythonhosted.org/packages/30/6e/32e67467f6154bf4f1c4f63b05acc5097cba4237d45bbeeea446b52e8ac1/coverage-7.15.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:337399ad2c93b3acd2a937627dae8b3e86b66707cd3d3e856347999aadf1ef8d", size = 253676 },
+    { url = "https://files.pythonhosted.org/packages/03/c1/8b24192e89286399765155251f99ee9f070a9d637109018ac23d99b99f6f/coverage-7.15.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:96e257121228ec5cd2bb919276e94ac11074471bc37d68dbae0e8308cce15fff", size = 255453 },
+    { url = "https://files.pythonhosted.org/packages/16/6f/8b41ebdf67c87854e17c035336a90f1cfbad0c14c2a584301be6ff148718/coverage-7.15.4-cp313-cp313-win32.whl", hash = "sha256:c65a9e0dfc6143491879da4e13b5e30f8be192055de508d737fb14601edbd22c", size = 224605 },
+    { url = "https://files.pythonhosted.org/packages/e0/e2/2946c7f0b42b152ecb21ff1bdad72e3d301e790c0c487e4a86e8c9f69347/coverage-7.15.4-cp313-cp313-win_amd64.whl", hash = "sha256:2ff8f5e9b8f7a94f0c11c45631eee103dbcb7d63274edd12c56efe1be690b3b4", size = 225148 },
+    { url = "https://files.pythonhosted.org/packages/9e/83/3f4a69957f48ae7a0aba76c34743f88963d607b19e03f3f8e66f91cae0f9/coverage-7.15.4-cp313-cp313-win_arm64.whl", hash = "sha256:6e0a8a5083b096487d6cfced94cdd514d8f5db6f113610fb36c0620edb1028cf", size = 224536 },
+    { url = "https://files.pythonhosted.org/packages/ea/ac/748cf29eeb2d6be34a3176ce26a4f49e38085ee08e8935f05f6f26ed7e0f/coverage-7.15.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:770e9325ab5ea6d56f77e59b29ecfe0ac20b57a82a601876f90494a4dda0386f", size = 222608 },
+    { url = "https://files.pythonhosted.org/packages/0b/02/1abbf5c984677b0aa439cdacaccbf38d248939d8ef8fe1cc7a50d73edb77/coverage-7.15.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d12b33a3a50a1676b7784dc8d00a0c6d66a9f2add4b85a041c19b6a7e53ef23c", size = 222940 },
+    { url = "https://files.pythonhosted.org/packages/eb/e1/ff8f9f53d9fcf586125b55d0b1f04ec1c14955fee41e83d5814bee141bb5/coverage-7.15.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5669c8378ebde86f5def7a25d29586631b58acc27ffde04399f678f3dfc6e082", size = 253985 },
+    { url = "https://files.pythonhosted.org/packages/a1/26/595759762e514e81be1d7d01ed03444303bcd152226a6529998d253f9201/coverage-7.15.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ff97a14362eef486483ed44042ca2027ea257df6ff768e62358ee0c9776925ac", size = 256492 },
+    { url = "https://files.pythonhosted.org/packages/24/68/b79aabac54d482be23b5fcdd4f4662bff24a78edc4ee29201726929936d5/coverage-7.15.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a325e815318638aed1655d9c06e6d7c2d3d46c09231ce988070428a8762d734", size = 257837 },
+    { url = "https://files.pythonhosted.org/packages/09/0f/bf7f297885a5bf6fd71e5782404e0ff059ca09e8711ceb3a08544abde45a/coverage-7.15.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:474223409d88eb20d2d6a0d37ea60e8647a65a90cc008dc1f0410af5f64f1e0d", size = 260152 },
+    { url = "https://files.pythonhosted.org/packages/fd/f1/296744e854ff8368542343457414380465e9ceefb9192342feb9d3bc461d/coverage-7.15.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7f2f62ae3cd189dd2e13aece758c57b3eecbd27be070dbd4cbd10936049e5dbf", size = 253978 },
+    { url = "https://files.pythonhosted.org/packages/55/b0/bbdb2e9057493e66220a2e149ca2d301ba0e3a58a83bd6b90de9826d16f3/coverage-7.15.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39ece820e29e0a2ba34b3ecb3be83c27e997eed8926f2ba6fe7ce7a0bda5843b", size = 255846 },
+    { url = "https://files.pythonhosted.org/packages/96/e4/38015b2b6d21258713bd17e76b59d033b191efb5703589cffd037dfbca20/coverage-7.15.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f21b56dcace11dfe013014201f577dcd592b2a9b72182d930361b47cf6f73f25", size = 253808 },
+    { url = "https://files.pythonhosted.org/packages/0b/64/0d515c1e60ee6fbfd1a0e79c07cd87d388a233b7adc37758735677203808/coverage-7.15.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:93a3a0b662abcc10c73a47cbc72cd60f63618d6989fb2d1286e50eacd974f303", size = 258081 },
+    { url = "https://files.pythonhosted.org/packages/91/71/04d9e7a3642146c6351338aef4ef85ab11dbbb54744c13245caba1aad1c0/coverage-7.15.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:141fae2cabf5569b782c10afc4c850ce10f618c13f8db54765cba99cc839da1f", size = 253624 },
+    { url = "https://files.pythonhosted.org/packages/b4/a7/6c28b74c81ebff66987b0e2522ba5cffa3e90b0c33cb6a2eb264d4ee8cf1/coverage-7.15.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:81294c7e6ab30c5f74c0353b11b2fd6320e72d9bee6ac73b357caa8b916323a5", size = 255280 },
+    { url = "https://files.pythonhosted.org/packages/52/af/bc19996a7014b98d7bbb0f0939453c67074af65784a3aa16a789a07381fa/coverage-7.15.4-cp314-cp314-win32.whl", hash = "sha256:7bbd7d6418e0dab31a206af5203bd43ae36edb8e7fba1940b055d3e9249290d7", size = 224768 },
+    { url = "https://files.pythonhosted.org/packages/ee/90/219484e476d6e101ba0a444852579e05f5b75c37c611a42ed1190f73ef62/coverage-7.15.4-cp314-cp314-win_amd64.whl", hash = "sha256:f0204ed122758782970526057093f448051a39db9d810d4e344bb87a3546f425", size = 225259 },
+    { url = "https://files.pythonhosted.org/packages/b7/66/fa77daf4e383e5f776dac62c2409b6af81910ae6fe326bd5170dba74cc63/coverage-7.15.4-cp314-cp314-win_arm64.whl", hash = "sha256:9e71e7bc71c686a123347ae47a0de33a175e797a85bb57b791492adf4eec8ed8", size = 224684 },
+    { url = "https://files.pythonhosted.org/packages/58/5b/f03bf0ce362bbf3f785fa5219620d00778d4ac6fc9e407734828e9c672f6/coverage-7.15.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7c922735321eef3f87c280a3d39afff6b646723a2880b862cda4ac7a093b8aa8", size = 223338 },
+    { url = "https://files.pythonhosted.org/packages/0f/76/e77d0ae22501831cc9f92193e8a957a5caa1dd177f90a6d1d9b106242d92/coverage-7.15.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f41c17c4668a655ce96d090d8d5ffdc24ef64b5a02f9753884d08483e8a4a41a", size = 223609 },
+    { url = "https://files.pythonhosted.org/packages/82/1a/b1f089da8d38ac612fa2dd6dc7f4a1a7657d12f3e261d2996edd3a838d0b/coverage-7.15.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46822e9b6ff1c6a72b518c162c44a8f45a61a1d609c51084bf5b16c023c5037b", size = 264970 },
+    { url = "https://files.pythonhosted.org/packages/bf/31/e66d98d6e9c7fcc88470f1e234eaf6b1950dc0dfbf797f7282c1c861da24/coverage-7.15.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d6f4955b73b5445271379a59e3792b0d978f42d4a01e0cf7a67d9c33a3bb0a5", size = 267088 },
+    { url = "https://files.pythonhosted.org/packages/59/a1/ae94eb2c541add426378408379f233591e069040b1e2cdb33df9498a0682/coverage-7.15.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3fc9e047706fb4a9abb54f719d3aa643e80e5bb3818182c40aee01ac0f0247ba", size = 269508 },
+    { url = "https://files.pythonhosted.org/packages/9c/c7/88a10694a1c6a213569766aba9f25847b28155d4ac731b13226db216356d/coverage-7.15.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05e491d4f3165d62d4f5c8fd48dfeabf2ae8f42cbbd484319af33ea851b78982", size = 270629 },
+    { url = "https://files.pythonhosted.org/packages/b3/34/d8b8232e5e55169933b59aabcef2fedfa4b9d8897361bb80fcbda146505f/coverage-7.15.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:226c66e80ec0598d3b9b4874123df167ccca342aca8714f77cac6829688ee09c", size = 264043 },
+    { url = "https://files.pythonhosted.org/packages/7e/35/58b009dbf8c471c7224716478b9fed4a7e1af15320e1ed41660978504663/coverage-7.15.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac41cc14bebda0dbfb0628036b7f75706935c95bcc07fefe9a0f93614aa60a57", size = 266963 },
+    { url = "https://files.pythonhosted.org/packages/62/aa/57fbda1b42c892968273c56b6ee9dc0f1310850859230a507bc7873b1f65/coverage-7.15.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8af623e5cd92080acddd02b38f2f406a2c3a0893c38950b211890361448fbf26", size = 264569 },
+    { url = "https://files.pythonhosted.org/packages/98/8a/360e6e7f24d477b7e889703af0afa878d15b6d4d8d2a822b2835c169a879/coverage-7.15.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07545711d4f0f32852a18f18ad11f76f0109909d09e78b9008b4cfc67e829429", size = 268299 },
+    { url = "https://files.pythonhosted.org/packages/4e/89/6f701261aee21b6b5fa8f7872229406dc917e125069448292223bf213606/coverage-7.15.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a0865421cfdc53654b342d515e5a233187590882d20b95752150e53f65460017", size = 263413 },
+    { url = "https://files.pythonhosted.org/packages/3f/0f/6f04036edc260ed425af83e834f627fad48941ce97b50bfe6edd8b6fa623/coverage-7.15.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:460115e32ee40566476db5048f9bec1e842c127ad8e6f8be745aad3ac9cbc839", size = 265725 },
+    { url = "https://files.pythonhosted.org/packages/c4/ce/d19b5d4d5c49a7bfb925fd74310fee7d28bc99520ac3367ccbc54e662518/coverage-7.15.4-cp314-cp314t-win32.whl", hash = "sha256:cbde877ef9dd7baf272b9bfef2b8a25edd45d9170fc326951dd20eb480335e85", size = 225079 },
+    { url = "https://files.pythonhosted.org/packages/26/bb/7aa1b3b173faee0679037ca950bbbe1247273656697994d8d13f80f8d4b4/coverage-7.15.4-cp314-cp314t-win_amd64.whl", hash = "sha256:3da9e92d1c551fd7563833e9ade686efb0c4b7363ab7681a94283958c950bf5e", size = 225911 },
+    { url = "https://files.pythonhosted.org/packages/81/1c/4ea9e47426d80038d9222db3c4534cb6021a74b237d3ff97ffd33b6600dd/coverage-7.15.4-cp314-cp314t-win_arm64.whl", hash = "sha256:3a54f5a0d85050c73a38f6793090ee83974531e67fe5e57a1da9bee11398aa5e", size = 225219 },
+    { url = "https://files.pythonhosted.org/packages/2b/c4/dc5d2ac8f9142e7ec7de66e7bf0591db29d78955a040bd915870d9c0e657/coverage-7.15.4-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:2c9872e4d9dc5d3cf616bf4b382f5a00359305a5be666a3dd0b5cdb4e49597f9", size = 222604 },
+    { url = "https://files.pythonhosted.org/packages/70/39/33e63df81fe2ee100897451841c821467635923e58e37c6bd4b46dd8106c/coverage-7.15.4-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:e101dbb4b9b72f0cddd8cdc8c9c5b47f456766f5e0ac82dbfb75e5c55409b78a", size = 222944 },
+    { url = "https://files.pythonhosted.org/packages/99/1f/ef3ffb5557febc75a0d97aa459d0266d7d741110265121cc6d8539343d44/coverage-7.15.4-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7d1abebdb047729e852b9c77a00497dfbeb11eb3a117e037d7dbc3ac8e5f5c54", size = 254050 },
+    { url = "https://files.pythonhosted.org/packages/6f/f5/1f0f6f77698c3601ca0ae7431e34b24c62ca2f06fecb23b73ed1f651d2be/coverage-7.15.4-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d28a4a899354d0ea6214cc59b4fa19eefbce1b9ff1688ab579acf49e894bd3fb", size = 256967 },
+    { url = "https://files.pythonhosted.org/packages/03/7a/2ed9bed79925f4367c83c77f66a89e5ca7229c288d2d19ad5f36d1ca0070/coverage-7.15.4-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb3c2aacea411cc7e1d27712490c11108e2de1d39019ae32915493a59a8b9ed", size = 258587 },
+    { url = "https://files.pythonhosted.org/packages/45/8c/fa34044f71b7cc4ecb6da9c2408770959b0591fa9b5fb6fb6bca38f94298/coverage-7.15.4-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a9447978a92f405d301123cfd39ff49895490efb769a758fe2734c7f631bf8ce", size = 260785 },
+    { url = "https://files.pythonhosted.org/packages/4f/54/d5727ce36b4524a7394ab9f5f1df378e1f23affcdab01037dc8655185cc7/coverage-7.15.4-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:050467a7983b8e2fe7dd41a78bb30c3e7f8c0b8cafda14b1c46f8b5e3cf2dd3c", size = 254545 },
+    { url = "https://files.pythonhosted.org/packages/dc/e6/6e3783e576719590194bdffb6dd6d85490801785b7c331e35a245d8cb8b5/coverage-7.15.4-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:d003b7a5708ddad5c206c79607a6b92abb6fc13c57d99d8a4468cc03a2941ced", size = 256682 },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/bacdbde18b69ed2de424fcf64d9fb0a4913753d4f0eca8bae9daad69f4bd/coverage-7.15.4-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c38efe30fd74e5c19e9433f11fb1f5dc9c6522770971b7c6145bbaa413dc8800", size = 254560 },
+    { url = "https://files.pythonhosted.org/packages/6c/a3/1fb927196e3477c1b48831169ab58ba08f451ba87ae311ff1de68b26a616/coverage-7.15.4-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:1f4f826d70f772ab8b0c052329580d7fe8b8abd191e4ce0c8f81aec6614665d3", size = 258792 },
+    { url = "https://files.pythonhosted.org/packages/41/58/30d4c149c69053de0edfe325614c1d28d508f62b1783e0e4a234d2e49136/coverage-7.15.4-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:4a4bf917c9953f57c957be31c1cd504e3bd2f34d4a352b9d391a3025336f6768", size = 253968 },
+    { url = "https://files.pythonhosted.org/packages/89/e4/77f639371b918aad30dda4051f95404b43578f7f2e2f87ba73e02ed1ff37/coverage-7.15.4-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:1c9bf40ebef178a45192c75c4964760bb261b0e6ad725da5fc4c93f674f19753", size = 255893 },
+    { url = "https://files.pythonhosted.org/packages/5c/62/13be29b3ddab35f14c87967a4820a05106d2a3eccb4fa4ff550bf30b75e0/coverage-7.15.4-cp315-cp315-win32.whl", hash = "sha256:43619d04c3671792d2c4706ae8bf45e265dc87bbd4078189ef8b847ea1e74be2", size = 224768 },
+    { url = "https://files.pythonhosted.org/packages/a1/70/af0c6be0f964af6954f6b74bc109b0dbca02824696d2520fb17fe1ab06e3/coverage-7.15.4-cp315-cp315-win_amd64.whl", hash = "sha256:be619439dbcd31a2eab10b32de9fff62c26ed4bab69dc32b8363fdaaa0882809", size = 225242 },
+    { url = "https://files.pythonhosted.org/packages/4f/2d/f3bd3aab899fc9efc18b53133ee68f5f98574ef480649b23e12962226387/coverage-7.15.4-cp315-cp315-win_arm64.whl", hash = "sha256:def597967dafc2e8d97c9097ea453c464e0bb8ed38f193a43070f10dc623bb6d", size = 224674 },
+    { url = "https://files.pythonhosted.org/packages/f5/ca/f69251cd63eabc6438321aea22148754cce758a26bde07dd490e3fe7cfc5/coverage-7.15.4-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c7dbc748ac8a1e3e59a2b28bea47675e6e778081dbbf081bde0d75def2fcbe1d", size = 223333 },
+    { url = "https://files.pythonhosted.org/packages/a7/a7/037b53b2885b0d8447064432491a4d5a1014cd9f97a594d53acd0c04541a/coverage-7.15.4-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:2413074a5ecbb61a01a7888fc72db0ca324d13588c5b38bc0dd8564cdcdfea26", size = 223630 },
+    { url = "https://files.pythonhosted.org/packages/80/4f/152b8a4779ae90da11bb24f7467df8a59f0be48a5c52acb856325ca48289/coverage-7.15.4-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4e6f6f632b7b2f714bf7a1346e8f97b650ee71f3c298aaad42a2ab60f0f07645", size = 264489 },
+    { url = "https://files.pythonhosted.org/packages/10/2d/84b4b9e0e1dd6528a51920ff7031f35b789382e467a28ec6a5a578cb8812/coverage-7.15.4-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8df457da2249d3c75ca2e5e835d59c725abfe92d27fdff6cd99eed85b51d5e9a", size = 267567 },
+    { url = "https://files.pythonhosted.org/packages/53/fc/ba01cc25299f9f8a2c8b02d3b28c53f3543d9fbfbe4e74fa2760b48f163e/coverage-7.15.4-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:050f66a08805acb5b8a23c6d4a517b1ecf82c08e81ed0e4bd727df065e5c6624", size = 270123 },
+    { url = "https://files.pythonhosted.org/packages/cf/d0/db2647cbf40b14f8c308f94ff7bf89c06d564e59f396906edf50086ec788/coverage-7.15.4-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1587fb771d1ccceef708fdde1e5af8c7ed24b486b61d13a321acb7d8145390aa", size = 271107 },
+    { url = "https://files.pythonhosted.org/packages/70/ff/4d2d17924552c458bb4f77dd631f0e3bc92fbbdf2d2d916cd4b33bbfd5b1/coverage-7.15.4-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8b4f1c3a69ca580f3fbd6b2046915f536d7f586874f25c1bb23add2a3c88d50f", size = 264955 },
+    { url = "https://files.pythonhosted.org/packages/ee/de/dc010c7a3691f396d93bbc26bfcafa1c2a3a351cd520470f15faf5795bd5/coverage-7.15.4-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:ffb58d7eff5b7f6ecc6fa21d6288ab7f968a212cb67d682c269c09b9eba3b66f", size = 267949 },
+    { url = "https://files.pythonhosted.org/packages/78/ea/dc96a11375e83c045c2f7c61fb6918277cfe9401db7c0f7b1d111a84b2e5/coverage-7.15.4-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:d9df165544774574ee004b953023d1bebada1894a80b1052a43d798b0f676e67", size = 264421 },
+    { url = "https://files.pythonhosted.org/packages/c8/86/b77131a0f9503ce461cd577076147d7a9040f0c5dda772686f729e2cc9cb/coverage-7.15.4-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:f9de0a24a4079b53e523b5c5e2c5945ec251ab486652659955187cf255a259bc", size = 269121 },
+    { url = "https://files.pythonhosted.org/packages/24/24/944bc35007862955e7ebf05754e645419dcf5d7526c52735cfa2715e8ebf/coverage-7.15.4-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:150089274bdc9f940628552cb92844e0223c987f1902ab8efe9f45a2ec758d88", size = 264565 },
+    { url = "https://files.pythonhosted.org/packages/c7/cc/a3bb9f93e7e740659163e2ea584f8196ddcd2c456a5dbe15f6c50105fec1/coverage-7.15.4-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:a58a94fed5da6997d258e8f7668c1e195fbd04a691d781b7558f1e468f9e68bc", size = 266522 },
+    { url = "https://files.pythonhosted.org/packages/49/dd/e0e40f3560d878d888c580698ff5ad1179f5e1c3ac949684ef66b41a3817/coverage-7.15.4-cp315-cp315t-win32.whl", hash = "sha256:ebd5a6d8466ff30836572f3ba2cae8a5e8f85029b1c6d5e2ed338dc472a5166a", size = 225068 },
+    { url = "https://files.pythonhosted.org/packages/c6/7e/37732ea80eebc30e976e4cdab15c190bc42d96959a42e38ddf6f8c60468f/coverage-7.15.4-cp315-cp315t-win_amd64.whl", hash = "sha256:288bde2a2d7ab6b6c2d7252fcde8b524387f2d970bdba9658fc6f8bbcaef0f9b", size = 225895 },
+    { url = "https://files.pythonhosted.org/packages/c6/08/1e00f7923eaaba45fb3d51dd794125fc766304b1df264f3a9c6557bfb30e/coverage-7.15.4-cp315-cp315t-win_arm64.whl", hash = "sha256:68be5e1de60ff13c9095bbec0e5a7fa45b33b101752215b91345ea1f61c4a278", size = 225213 },
+    { url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl", hash = "sha256:964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84", size = 214332 },
 ]
 
 [[package]]
@@ -1619,6 +1719,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075 },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1755,6 +1882,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481 },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557 },
 ]
 
 [[package]]


### PR DESCRIPTION
Foundation slice of the **Agents API v2** milestone. Closes CAR-150 and CAR-153.

No behaviour change to the pipeline — this is test infrastructure plus the two lazy-loading fixes it required.

## CAR-150 — dev tooling was never installed

`pyproject.toml` declared dev dependencies in two places that disagreed:

| | |
|---|---|
| `[project.optional-dependencies].dev` | `ruff`, `pytest`, `mypy` |
| `[dependency-groups].dev` | `ruff` only |

`uv sync` reads the latter, so **`pytest` and `mypy` had never actually been installed** — which is why this service has no test suite. Consolidated on `[dependency-groups]`, added `pytest-asyncio`, `pytest-cov` and `respx`, and added `[tool.pytest.ini_options]` / `[tool.mypy]`.

`pythonpath = ["."]` is needed because the service is deployed as an application rather than installed as a package, so the project root isn't otherwise on `sys.path`.

## CAR-153 — hermetic test harness

**No test may open a non-loopback socket**, enforced by a session-scoped autouse fixture rather than by convention. CI minutes are free on a public repo, but a live LLM or enrichment call is billed out of pocket on *every* push — a convention doesn't stop that. Loopback stays open so Postgres/Redis service containers remain reachable.

46 tests, 9.5s:

| Area | Tests |
|---|---|
| Network guard | 8 |
| Job classification agent | 13 |
| Location agent | 15 |
| Seniority agent | 5 |
| ESCO reranking | 5 |

## Two lazy-loading fixes were prerequisites, not cleanups

Both of these reached out to the network **at import time**, which made their modules — and `app.main` with them — impossible to import without network access:

- `esco_reference.py` constructed a `CrossEncoder` at module scope → HuggingFace Hub on a cold cache
- `location.py` resolved the tiktoken encoding at module scope → BPE vocabulary download

Both now load on first use behind an `lru_cache`d accessor, which also takes them off the startup path. `scripts/prefetch_models.py` still warms the HF cache at build time for Railway; that just never helped CI or a fresh checkout.

Also moved `declarative_base` to its SQLAlchemy 2.0 location — its deprecation warning was failing collection under the new `filterwarnings` rule.

## Bug found while writing the tests

`seniority.classify_seniority` and `job_classification._validate_single` both `return state` **only inside `if tool_call:`**, so a model response with no matching tool call yields `None`. In job classification that's the worse case: `asyncio.gather` collects the `None`, and `batch_update_classifications` then raises on `None["role"]`.

`location.resolve_geo` gets this right — it returns state outside the branch and records the error — which is what makes the other two look like oversights rather than design.

Both are recorded as `xfail(strict=True)` rather than fixed here, so CAR-103 inherits a spec and the tests flip to passing the moment they're addressed.

## Notes for CAR-154 (CI)

Neither linter can be turned into a gate as-is:

- **`ruff check` has never passed** — 52 pre-existing violations on `main` (44 line-length, 5 unused imports, 1 unsorted import, 1 ambiguous name, 1 unused variable). This PR adds none.
- **`mypy` reports 193 errors across 26 files** (158 with `check_untyped_defs` off).

CI will need to land as two steps: fix the baseline, then enable the gate.

## Verification

```
uv sync --group dev && uv run pytest    # 44 passed, 2 xfailed in 9.5s
uv run ruff check tests/                # clean
uv run ruff format --check tests/       # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD
