### PR TITLE
ci: repair VM backend deploy for the pnpm monorepo

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -6,6 +6,13 @@ on:
       - main
     paths:
       - "api/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+# Never let two deploys touch the VM at once.
+concurrency:
+  group: deploy-backend
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -14,43 +21,51 @@ jobs:
     environment: Production – alumni-feup
 
     steps:
-      - name: Check API health before deployment
+      - name: Check API is up before deployment
         run: |
-          if ! curl -s http://localhost:3010/health; then
-            echo "❌ API is not healthy before deployment"
-            exit 1
+          if ! curl -sf --max-time 10 http://localhost:3010/health; then
+            echo "API did not answer /health before deployment."
+            echo "Continuing - /health is not implemented yet, so this is informational."
           fi
 
       - name: Pull latest backend code and restart
         run: |
-          cd ~/newAlumniProj/api
-          echo "📥 Pulling latest changes..."
+          set -euo pipefail
+          cd ~/newAlumniProj
+
+          echo "Pulling latest changes..."
           git pull origin main
 
-          echo "📦 Installing dependencies..."
-          yarn install --frozen-lockfile
+          # The repo is a pnpm workspace (pnpm-workspace.yaml lists app + api),
+          # so install runs from the root, not from api/. corepack pins the
+          # version declared in the root package.json's packageManager field.
+          echo "Installing dependencies..."
+          corepack enable
+          pnpm install --frozen-lockfile --filter api...
 
-          echo "🔨 Generating Prisma client..."
-          yarn prisma generate
+          echo "Generating Prisma client..."
+          pnpm db:generate
 
-          echo "🔄 Running migrations..."
-          yarn prisma migrate deploy
+          echo "Running migrations..."
+          pnpm db:migrate:prod
 
-          echo "🏗️ Building application..."
-          yarn build
+          echo "Building API..."
+          pnpm --filter api build
 
-          echo "🔄 Restarting API..."
+          echo "Restarting API..."
           pm2 restart api --update-env
 
-          # Wait for API to be ready
-          echo "⏳ Waiting for API to be ready..."
-          sleep 5
+      - name: Verify the API came back
+        run: |
+          echo "Waiting for API to be ready..."
+          for i in $(seq 1 15); do
+            if curl -s --max-time 5 -o /dev/null http://localhost:3010/; then
+              echo "API is accepting connections."
+              exit 0
+            fi
+            sleep 2
+          done
 
-          # Check if API is healthy after deployment
-          if ! curl -s http://localhost:3010/health; then
-            echo "❌ API is not healthy after deployment"
-            pm2 logs api --lines 50
-            exit 1
-          fi
-
-          echo "✅ Deployment successful!"
+          echo "API did not accept connections within 30s"
+          pm2 logs api --lines 50 --nostream
+          exit 1


### PR DESCRIPTION
Repairs `deploy-backend.yml` so it can be re-enabled. **Does not re-enable it** — that's a separate, deliberate step (see below).

## Why it needs repair

The workflow is currently `disabled_manually`. Its last successful run was **`a8fdca4` on 2026-03-23**. Three days later, **`bfba945` (#63)** migrated the repo to pnpm:

```
api/yarn.lock  | 8339 ------------
app/yarn.lock  | 7094 ------------
pnpm-lock.yaml | 15308 ++++++++++++
```

It has not run since, so it has never met the current layout. Re-enabling it as-is fails: the step runs `git pull origin main` **first**, which applies that deletion to the VM checkout, and then `yarn install --frozen-lockfile` has no lockfile to work from.

Thirteen commits have touched `api/` since that last run.

## Required changes

| | |
|---|---|
| **yarn → pnpm** | The lockfile it depends on no longer exists. Root declares `packageManager: pnpm@10.28.2`, so `corepack` pins the version. Prisma goes through the root scripts (`db:generate`, `db:migrate:prod`). |
| **Install from the repo root** | `pnpm-workspace.yaml` makes the root the workspace root — installing from inside `api/` doesn't resolve. `--filter api...` keeps the VM from installing or building the Next.js app it never runs. |

## Smaller changes, none load-bearing

- Trigger on `pnpm-lock.yaml` / `pnpm-workspace.yaml` as well as `api/**`, so a dependency bump actually reaches the VM.
- A `concurrency` group, so two pushes can't deploy over each other mid-migration.
- The pre-deploy gate used `curl -s` without `-f`, so a 404 passed it. **The API has no `/health` endpoint** — no controller defines one — so the check only ever proved something was listening on 3010. Made that explicit and non-fatal, and replaced the fixed `sleep 5` afterwards with a retry loop that tails `pm2` logs on failure.

Happy to drop these three if you'd rather keep the diff to the minimum.

## Before enabling

**Merge this first, then `gh workflow enable "Deploy Backend"`** — not the other way round. The disabled flag is repo-level, so enabling before the fix lands means any `api/**` push to `main` runs the old yarn version and fails at install, after the pull has already moved the checkout.

Two assumptions I inferred from the original script and can't verify from here:

- The repo checkout root on the VM is `~/newAlumniProj` (the old script did `cd ~/newAlumniProj/api` then `git pull`). This version `cd`s to the root directly.
- `corepack` is available on the runner. If not, `npm i -g pnpm@10.28.2` and drop the `corepack enable` line.

## Follow-ups worth separate tickets

- A real `/health` endpoint on the NestJS API, so the deploy gate verifies the app rather than the port.
- **agents-api now has nowhere to deploy.** CAR-123 and #76–#80 targeted Railway; with Railway off, `agents-api/railpack.json` and `railway.toml` are dead config and the service needs a home on the VM. It's arguably a better fit there — it queries pgvector heavily for ESCO search, so co-locating with Postgres removes a hop from the hottest path, and Redis is already on the box for the arq queue.
- **CAR-124** ("Backup prod DB and restore to Railway Postgres", Urgent) is obsolete and should be cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD
