### PR TITLE
ci: guard the DB sync against destroying ESCO embeddings

### DIFF
--- a/.github/workflows/sync-db-to-railway.yml
+++ b/.github/workflows/sync-db-to-railway.yml
@@ -31,6 +31,11 @@ on:
         type: string
         required: false
         default: ""
+      allow_embedding_loss:
+        description: "Override the guard that blocks a sync which would destroy ESCO embeddings."
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: sync-db-to-railway
@@ -127,6 +132,59 @@ jobs:
           echo
           echo "--- target (Railway), before ---"
           psql "$TARGET_URL" -tA -F' ' -c "$COUNTS" || echo "(target may be empty)"
+
+      - name: Compare extensions and ESCO embeddings
+        run: |
+          set -euo pipefail
+          # Railway holds ~3000 OpenAI text-embedding-3-large vectors on
+          # esco_classification. They cost real money to generate, and
+          # agents-api has never run in production on the VM - so the source may
+          # not have pgvector installed at all. Surface that before anything
+          # destructive happens.
+          echo "--- extensions: source (VM) ---"
+          psql "$SOURCE_URL" -tA -F' ' -c "select extname, extversion from pg_extension order by 1"
+          echo
+          echo "--- extensions: target (Railway) ---"
+          psql "$TARGET_URL" -tA -F' ' -c "select extname, extversion from pg_extension order by 1"
+          echo
+
+          EMB="select count(*) || ' rows, ' || count(embedding) || ' with embeddings'
+               from esco_classification"
+          echo "esco_classification, source : $(psql "$SOURCE_URL" -tAc "$EMB" 2>/dev/null || echo 'table or column absent')"
+          echo "esco_classification, target : $(psql "$TARGET_URL" -tAc "$EMB" 2>/dev/null || echo 'table or column absent')"
+          echo
+          echo "--- tables on the target that the source lacks ---"
+          echo "(--clean will NOT drop these; they survive the restore)"
+          comm -13 \
+            <(psql "$SOURCE_URL" -tAc "select table_name from information_schema.tables where table_schema='public' order by 1") \
+            <(psql "$TARGET_URL" -tAc "select table_name from information_schema.tables where table_schema='public' order by 1") \
+            || true
+
+      - name: Guard against destroying embeddings
+        if: inputs.mode == 'sync'
+        run: |
+          set -euo pipefail
+          COUNT="select count(embedding) from esco_classification"
+          SRC=$(psql "$SOURCE_URL" -tAc "$COUNT" 2>/dev/null || echo 0)
+          TGT=$(psql "$TARGET_URL" -tAc "$COUNT" 2>/dev/null || echo 0)
+          SRC=${SRC:-0}; TGT=${TGT:-0}
+          echo "embeddings - source: $SRC, target: $TGT"
+
+          if [ "$SRC" -lt "$TGT" ]; then
+            echo
+            echo "The source has fewer ESCO embeddings than the target."
+            echo "Syncing would replace $TGT embeddings with $SRC and they would"
+            echo "have to be regenerated against the OpenAI API at real cost."
+            if [ "${{ inputs.allow_embedding_loss }}" != "true" ]; then
+              echo
+              echo "Refusing. Re-run with allow_embedding_loss = true if this is intended,"
+              echo "or exclude esco_classification from the dump and sync the rest."
+              exit 1
+            fi
+            echo "allow_embedding_loss is set - continuing anyway."
+          else
+            echo "Source is not behind the target. Safe to proceed."
+          fi
 
       - name: Replace the Railway database
         if: inputs.mode == 'sync'


### PR DESCRIPTION
Fixes a gap in #84 that I should have caught before writing that workflow.

## The problem

Railway's `esco_classification` holds **3658 rows with 3039 embeddings** — OpenAI `text-embedding-3-large` at 3072 dimensions, backed by `pgvector 0.8.2`. Those cost real money to generate.

agents-api has **never run in production on the VM** (that's what CAR-102/CAR-123 were about), so the VM's Postgres may not have pgvector installed, or may have `esco_classification` without embeddings. A straight dump-and-replace would then wipe 3039 vectors and break job classification until they were regenerated at cost.

The sync workflow as merged counts `alumni`, `role`, `company`, `course`, `location`, `graduation` and `_prisma_migrations` — none of which would have shown this.

## Changes

**Inspect mode** now also reports, for both databases:
- installed extensions (so a missing `vector` on the source is obvious)
- `esco_classification` row count *and* embedding count
- tables present on the target but absent from the source — `--clean` does not drop those, so they survive the restore as orphans

**Sync mode** gains a pre-flight guard: it compares embedding counts and **refuses to run** when the source has fewer than the target. `allow_embedding_loss: true` overrides it.

## Findings from the diagnostics run

Both of #83's unverified assumptions now confirmed, plus one that isn't:

| | |
|---|---|
| Repo root | `/home/eic30anos/newAlumniProj` — as assumed |
| Checkout | `a8fdca4` (2026-03-23), **22 commits behind** `main` |
| `corepack` | present, **0.28.1** |
| `pnpm` | **ABSENT** |
| pm2 | `api` online (4 months, 32 restarts), `github-runner` online |

**`pnpm` being absent is fine — `corepack 0.28.1` being old may not be.** The root pins `pnpm@10.28.2`, and corepack releases from that era are known to fail signature verification on much newer package manager versions. If `Deploy Backend` fails at `corepack enable`, the fix is `npm i -g corepack@latest` on the VM (or `npm i -g pnpm@10.28.2` and drop the corepack line). Worth knowing before enabling, not during.

Also confirmed the VM's Postgres binds `0.0.0.0:5432` but is firewalled — only 443 is reachable externally, so it isn't publicly exposed, and there's no shortcut around the runner for the dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD
