### PR TITLE
ci: stop a truncated dump from half-writing the Railway database

### DIFF
--- a/.github/workflows/sync-db-to-railway.yml
+++ b/.github/workflows/sync-db-to-railway.yml
@@ -233,7 +233,18 @@ jobs:
           # emptied as part of the restore rather than in a separate step.
           # --no-owner/--no-privileges because the roles differ between the VM
           # and Railway; without them every GRANT and ALTER OWNER fails.
-          echo "Streaming dump into Railway. This replaces every table."
+          # Deliberately NOT piping pg_dump straight into psql. On a mid-stream
+          # pg_dump failure psql sees a clean EOF, has no error to trip
+          # ON_ERROR_STOP on, and commits the partial restore - leaving the
+          # target half-written. Dumping to a file first means a truncated dump
+          # is caught before anything touches Railway.
+          #
+          # The file stays on the VM, which already holds this data, and is
+          # removed in the always() cleanup step below. It is never uploaded.
+          DUMP=$(mktemp /tmp/alumni-sync-XXXXXX.sql)
+          echo "DUMP_FILE=$DUMP" >> "$GITHUB_ENV"
+          chmod 600 "$DUMP"
+
           echo "pg_dump binary: ${PG_DUMP}"
           # PG_DUMP may be a plain path or a `sudo docker exec ...` prefix, so it
           # is intentionally word-split here rather than quoted.
@@ -243,12 +254,39 @@ jobs:
             --clean --if-exists \
             --no-owner --no-privileges \
             --quote-all-identifiers \
-          | psql "$TARGET_URL" \
-              --quiet \
-              --set ON_ERROR_STOP=on \
-              --single-transaction
+            > "$DUMP"
+
+          BYTES=$(stat -c%s "$DUMP")
+          echo "dump written: $BYTES bytes"
+          if [ "$BYTES" -lt 100000 ]; then
+            echo "Dump is implausibly small for ~3300 alumni. Refusing to restore."
+            exit 1
+          fi
+          # pg_dump terminates a complete plain dump with this marker.
+          if ! tail -5 "$DUMP" | grep -q "PostgreSQL database dump complete"; then
+            echo "Dump has no completion marker - it is truncated. Refusing to restore."
+            exit 1
+          fi
+          echo "Dump looks complete."
+
+          echo "Restoring into Railway. This replaces every table."
+          psql "$TARGET_URL" \
+            --quiet \
+            --set ON_ERROR_STOP=on \
+            --single-transaction \
+            --file "$DUMP"
 
           echo "Restore completed."
+
+      - name: Remove the local dump
+        if: always()
+        run: |
+          if [ -n "${DUMP_FILE:-}" ] && [ -f "$DUMP_FILE" ]; then
+            shred -u "$DUMP_FILE" 2>/dev/null || rm -f "$DUMP_FILE"
+            echo "Removed $DUMP_FILE"
+          else
+            echo "No dump file to remove."
+          fi
 
       - name: Row counts after
         if: inputs.mode == 'sync'


### PR DESCRIPTION
Correcting a flaw in my own design before anyone runs sync mode.

## The bug

I claimed `--single-transaction` made a failed restore roll back. **That only holds when `psql` errors.** If `pg_dump` dies mid-stream — container hiccup, dropped connection — psql reaches a clean EOF, has nothing to trip `ON_ERROR_STOP` on, and **commits the partial restore**. `pipefail` surfaces the failure only afterwards, once Railway is already half-written.

That's the one outcome worse than not syncing at all: production data replaced with a truncated copy, and no VM access to investigate.

## The fix

Dump to a file, validate, then restore:

- reject a dump under 100KB (impossible for ~3300 alumni)
- require pg_dump's `PostgreSQL database dump complete` trailer, which a truncated file won't have
- restore with `--file`, so psql applies a verified-complete dump or nothing

The file is mode 600, lives only on the VM — which already holds this data — and is `shred`ed in an `always()` step so it goes even when the restore fails. **Never uploaded**: artifacts on a public repo are publicly downloadable, and this includes `personal_email` and `linkedin_url` for ~3300 people. Disk is fine, 21G free.

## Selection step confirmed working

```
server major: 17
  /usr/bin/pg_dump                   -> major 14
  /usr/lib/postgresql/14/bin/pg_dump -> major 14
Falling back to the Postgres container's own binary.
Using container postgres: pg_dump (PostgreSQL) 17.4
```

After this merges, re-run `inspect` once, then `sync` + `REPLACE-RAILWAY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD