### PR TITLE
chore(dev): match local Postgres to production and namespace the stack

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,9 +1,9 @@
-version: '3.8'
+name: alumni-feup
 
 services:
   postgres:
-    image: pgvector/pgvector:pg17
-    container_name: postgres
+    image: pgvector/pgvector:pg18
+    container_name: alumni-feup-postgres
     restart: always
     environment:
       POSTGRES_USER: postgres
@@ -12,18 +12,18 @@ services:
     ports:
       - "5434:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - alumni_feup_postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5
     networks:
-      - app_network
+      - alumni_feup_network
 
   redis:
     image: redis:7
-    container_name: redis
+    container_name: alumni-feup-redis
     restart: always
     ports:
       - "6380:6379"
@@ -33,11 +33,11 @@ services:
       timeout: 5s
       retries: 5
     networks:
-      - app_network
+      - alumni_feup_network
 
 volumes:
-  postgres_data:
+  alumni_feup_postgres_data:
 
 networks:
-  app_network:
+  alumni_feup_network:
     driver: bridge


### PR DESCRIPTION
Local ran `pgvector:pg17` while Railway runs **18.4**. That blocks pulling a copy of production — `pg_dump` refuses to dump a server newer than itself, so a pg17 client can't read Railway at all. Same class of failure that blocked the VM sync, in the opposite direction.

## Why it isn't a one-line bump

**Postgres 18 changed the mount convention.** It expects a single mount at `/var/lib/postgresql` and creates the `data` subdirectory itself. Keeping the old `/var/lib/postgresql/data` mount makes the container crash-loop with an error that reads like a failed `pg_upgrade`:

```
This is usually the result of upgrading the Docker image without
upgrading the underlying database using "pg_upgrade"...
The suggested container configuration for 18+ is to place a single mount
at /var/lib/postgresql
```

The volume is consequently **new, not migrated** — Postgres won't start on a data directory from a different major version regardless.

## Namespacing

`container_name: postgres` / `redis` would collide with any other project on the machine, and without `name:` the compose project defaults to the directory name — just `website`. Now `alumni-feup-postgres`, `alumni-feup-redis`, and an `alumni-feup` project.

Also drops the obsolete `version` attribute compose warns about.

## Verified

```
PostgreSQL 18.4 (Debian 18.4-1.pgdg12+1)   pgvector 0.8.6
```

Same versions as Railway, and a full production dump restores cleanly:

```
alumni 3302 · role 8209 · company 2472 · course 10 · embeddings 3039
```

Local can now rehearse migrations against real data before they touch production — relevant immediately, since CAR-155 adds three tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD