### PR TITLE
ci: skip Vercel builds when the frontend has not changed

### DIFF
--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./ ../pnpm-lock.yaml ../pnpm-workspace.yaml ../package.json"
+}


### PR DESCRIPTION
Vercel deployed on **every** push — including commits touching only `agents-api/` or the Prisma schema. Root Directory is `app`, but that only scopes the *build*; it doesn't gate the *trigger*.

## Why `vercel.json` rather than the dashboard

Both work, and `ignoreCommand` takes precedence over the dashboard's Ignored Build Step. But this way the rule is version-controlled and shows up in review.

Today already surfaced **two** settings the pnpm migration left stale in dashboards — the VM deploy workflow (`yarn install --frozen-lockfile` against a repo with no yarn.lock) and Vercel's own Install Command (silently ignoring `pnpm-lock.yaml` and resolving fresh every build). Keeping this in the repo avoids adding a third.

It also answers "where is that setting?" permanently — it's in the file.

## The command

```json
"ignoreCommand": "git diff --quiet HEAD^ HEAD ./ ../pnpm-lock.yaml ../pnpm-workspace.yaml ../package.json"
```

Vercel runs it **from the Root Directory**, so `./` is `app/`. The workspace manifests are listed explicitly with `../` because a dependency bump changes the build without touching `app/`.

Per Vercel's docs: **exit 0 skips, exit 1 builds.**

## Verified both directions

A command that always returns 0 would silently stop deploying the frontend forever, so I checked against real commits rather than reasoning about it:

| commit | touches | exit | outcome |
|---|---|---|---|
| `cdf0aa2` (CAR-155) | `api/`, `agents-api/` | **0** | skipped ✓ |
| `acc7ecb` | `app/` + lockfile | **1** | builds ✓ |

Skipped builds still report the `Vercel` status, so branch protection won't hang waiting on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD