### PR TITLE
test(agents-api): add database test harness and pipeline model coverage

### DIFF
--- a/.github/workflows/agents-api-tests.yml
+++ b/.github/workflows/agents-api-tests.yml
@@ -50,7 +50,10 @@ jobs:
 
       - name: Apply the Prisma schema to the test database
         working-directory: .
-        run: npx --yes prisma@6 migrate deploy --schema api/prisma/schema.prisma
+        # Pinned to the exact version in api/package.json - a floating major
+        # would let CI apply migrations with a different Prisma than the app
+        # runs. Keep the two in sync.
+        run: npx --yes prisma@6.19.2 migrate deploy --schema api/prisma/schema.prisma
         env:
           DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
 

--- a/.github/workflows/agents-api-tests.yml
+++ b/.github/workflows/agents-api-tests.yml
@@ -1,12 +1,5 @@
 name: agents-api tests
 
-# Deliberately NOT path-filtered to agents-api/**.
-#
-# A required status check that never runs blocks the PR forever - GitHub waits
-# for a check that will never report. Since this is a required check, it has to
-# run on every PR. The suite is ~10s and the uv cache makes installs cheap after
-# the first run, so the cost is small.
-
 on:
   pull_request:
   push:
@@ -25,6 +18,24 @@ jobs:
       run:
         working-directory: agents-api
 
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: agents_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/agents_test
+
     steps:
       - uses: actions/checkout@v4
 
@@ -37,17 +48,19 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      - name: Apply the Prisma schema to the test database
+        working-directory: .
+        run: npx --yes prisma@6 migrate deploy --schema api/prisma/schema.prisma
+        env:
+          DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
+
       - name: Install dependencies
         run: uv sync --group dev
 
       - name: Lint the test suite
-        # app/ still has 52 pre-existing violations, so it cannot gate yet.
-        # tests/ is clean - keep it that way rather than letting it rot too.
         run: |
           uv run ruff check tests/
           uv run ruff format --check tests/
 
       - name: Run tests
-        # The suite is hermetic: a session-scoped fixture refuses any
-        # non-loopback socket, so no test can reach a paid API from CI.
         run: uv run pytest -q

--- a/agents-api/tests/conftest.py
+++ b/agents-api/tests/conftest.py
@@ -32,6 +32,7 @@ for _key in (
 import socket  # noqa: E402
 
 import pytest  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
 
 # Loopback stays open so tests can reach a Postgres/Redis service container.
 # Everything else is refused.
@@ -112,3 +113,73 @@ def block_network() -> None:
 def allow_loopback_check():
     """Expose the guard's predicate so tests can assert on it directly."""
     return _is_allowed
+
+
+# --- database fixtures --------------------------------------------------------
+#
+# Opt-in. Most of the suite never touches a database and stays hermetic; these
+# fixtures exist for the code where the database *is* the behaviour under test,
+# starting with session scoping (CAR-115).
+#
+# Loopback is permitted by the network guard above, so a local container or a CI
+# service container both work.
+
+# CI provides this; locally it defaults to docker-compose-dev.yml.
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL", "postgresql://postgres:secret@localhost:5434/postgres"
+)
+
+
+@pytest.fixture(scope="session")
+def db_engine():
+    """Engine for the test database, or skip if it is not reachable.
+
+    Skipping locally keeps `pytest` working for contributors without Docker.
+    In CI the service container is guaranteed, so an unreachable database is a
+    real failure - silently skipping there would report green on tests that
+    never ran.
+    """
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine(TEST_DATABASE_URL, poolclass=NullPool)
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("select 1 from pipeline_run limit 0"))
+    except Exception as exc:  # noqa: BLE001
+        reason = (
+            f"Test database unavailable or schema not applied at "
+            f"{TEST_DATABASE_URL.rsplit('@', 1)[-1]}: {type(exc).__name__}. "
+            "Start it with `docker compose -f docker-compose-dev.yml up -d` and apply "
+            "the Prisma migrations."
+        )
+        if os.environ.get("CI"):
+            pytest.fail(reason)
+        pytest.skip(reason)
+
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+def db(db_engine):
+    """A session wrapped in a transaction that is always rolled back.
+
+    Isolation without truncating: the outer transaction is never committed, so
+    a test can commit freely and still leave the database untouched. That
+    matters here because the local database holds a copy of production.
+    """
+    from sqlalchemy.orm import sessionmaker
+
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    session = sessionmaker(bind=connection)()
+    try:
+        yield session
+    finally:
+        session.close()
+        # A test that provoked an IntegrityError has already left the
+        # transaction aborted, so rolling back again warns. Only roll back what
+        # is still live.
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()

--- a/agents-api/tests/test_pipeline_models.py
+++ b/agents-api/tests/test_pipeline_models.py
@@ -1,0 +1,191 @@
+"""Database-backed tests for the pipeline tables.
+
+These are the first tests in the suite that touch a real database. They use the
+`db` fixture, which wraps each test in a transaction that is always rolled back,
+so they are safe to run against the local container even though it holds a copy
+of production.
+
+The pipeline tables are the state model the rest of Agents API v2 is built on
+(CAR-155), so their constraints are worth pinning rather than trusting.
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.db.models import (
+    PipelineEntityType,
+    PipelineKind,
+    PipelineRun,
+    PipelineRunStatus,
+    PipelineStage,
+    PipelineStageName,
+    PipelineStageStatus,
+    PipelineTask,
+    PipelineTaskStatus,
+)
+
+
+@pytest.fixture
+def run(db):
+    r = PipelineRun(kind=PipelineKind.REFRESH_EXISTING)
+    db.add(r)
+    db.flush()
+    return r
+
+
+@pytest.fixture
+def stage(db, run):
+    s = PipelineStage(run_id=run.id, stage=PipelineStageName.CLASSIFY_ROLES, sequence=3)
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _task(stage, key, entity_id="role-1", **kw):
+    return PipelineTask(
+        stage_id=stage.id,
+        entity_type=PipelineEntityType.ROLE,
+        entity_id=entity_id,
+        idempotency_key=key,
+        **kw,
+    )
+
+
+# --- defaults -----------------------------------------------------------------
+
+
+def test_a_new_run_starts_in_planning(db, run):
+    """Runs begin by working out what they would do, not by doing it."""
+    db.refresh(run)
+    assert run.status == PipelineRunStatus.PLANNING
+
+
+def test_a_new_stage_starts_pending(db, stage):
+    db.refresh(stage)
+    assert stage.status == PipelineStageStatus.PENDING
+    assert (stage.total_count, stage.succeeded_count, stage.failed_count) == (0, 0, 0)
+
+
+def test_a_new_task_starts_queued(db, stage):
+    task = _task(stage, "k-queued")
+    db.add(task)
+    db.flush()
+    db.refresh(task)
+
+    assert task.status == PipelineTaskStatus.QUEUED
+    assert task.attempts == 0
+
+
+# --- the dedup guarantee ------------------------------------------------------
+
+
+def test_duplicate_idempotency_key_is_rejected(db, stage):
+    """CAR-116's deduplication, enforced by the database rather than by workers
+    remembering to check. Two workers racing on the same entity cannot both win.
+    """
+    db.add(_task(stage, "k-dup"))
+    db.flush()
+
+    db.add(_task(stage, "k-dup"))
+    with pytest.raises(IntegrityError):
+        db.flush()
+
+
+def test_distinct_keys_coexist(db, stage):
+    db.add(_task(stage, "k-1", entity_id="role-1"))
+    db.add(_task(stage, "k-2", entity_id="role-2"))
+    db.flush()
+
+    assert db.query(PipelineTask).filter_by(stage_id=stage.id).count() == 2
+
+
+# --- relationships and cleanup ------------------------------------------------
+
+
+def test_deleting_a_run_removes_its_stages_and_tasks(db, run, stage):
+    """A cancelled or purged run must not leave orphaned rows behind."""
+    db.add(_task(stage, "k-cascade"))
+    db.flush()
+
+    db.delete(run)
+    db.flush()
+
+    assert db.query(PipelineStage).filter_by(run_id=run.id).count() == 0
+    assert db.query(PipelineTask).filter_by(stage_id=stage.id).count() == 0
+
+
+def test_run_reaches_its_tasks_through_stages(db, run, stage):
+    db.add(_task(stage, "k-nav"))
+    db.flush()
+    db.refresh(run)
+
+    assert [t.entity_id for s in run.stages for t in s.tasks] == ["role-1"]
+
+
+# --- the result payload -------------------------------------------------------
+
+
+def test_result_round_trips_as_json(db, stage):
+    """`result` is the baseline CAR-106 and CAR-108 measure against, so it has
+    to survive the round trip with its types intact - a float that comes back a
+    string makes confidence comparisons silently wrong.
+    """
+    payload = {
+        "esco_code": "2512",
+        "confidence": 0.91,
+        "model_used": "gpt-4o-mini",
+        "candidates": [{"code": "2512", "score": 0.91}, {"code": "2519", "score": 0.44}],
+    }
+    task = _task(stage, "k-result", result=payload)
+    db.add(task)
+    db.flush()
+    db.expire(task)
+
+    stored = db.get(PipelineTask, task.id).result
+    assert stored == payload
+    assert isinstance(stored["confidence"], float)
+
+
+def test_skip_reason_records_why_work_was_not_done(db, stage):
+    """A plan that skips 177 companies has to be able to say why."""
+    task = _task(stage, "k-skip", status=PipelineTaskStatus.SKIPPED, skip_reason="fresh")
+    db.add(task)
+    db.flush()
+    db.refresh(task)
+
+    assert task.status == PipelineTaskStatus.SKIPPED
+    assert task.skip_reason == "fresh"
+
+
+# --- stage ordering -----------------------------------------------------------
+
+
+def test_a_stage_cannot_appear_twice_in_one_run(db, run):
+    db.add(PipelineStage(run_id=run.id, stage=PipelineStageName.LINKEDIN, sequence=1))
+    db.flush()
+
+    db.add(PipelineStage(run_id=run.id, stage=PipelineStageName.LINKEDIN, sequence=2))
+    with pytest.raises(IntegrityError):
+        db.flush()
+
+
+def test_stages_order_by_sequence_not_insertion(db, run):
+    """Ordering comes from `sequence` so that inserting a stage in the middle
+    later does not silently reorder existing runs.
+    """
+    for name, seq in [
+        (PipelineStageName.LOCATION, 5),
+        (PipelineStageName.PLAN, 0),
+        (PipelineStageName.COMPANY, 2),
+    ]:
+        db.add(PipelineStage(run_id=run.id, stage=name, sequence=seq))
+    db.flush()
+
+    ordered = (
+        db.query(PipelineStage).filter_by(run_id=run.id).order_by(PipelineStage.sequence).all()
+    )
+    assert [s.stage for s in ordered] == [
+        PipelineStageName.PLAN,
+        PipelineStageName.COMPANY,
+        PipelineStageName.LOCATION,
+    ]


### PR DESCRIPTION
Groundwork for **CAR-115**. That refactor touches ~78 call sites across 12 files, and there is currently no test that would notice a missed one — the failure mode is a stale shared session, which is *intermittent* rather than immediate. Net first.

## CI gets a Postgres service container

`pgvector/pgvector:pg18` — the same image and major version as Railway and `docker-compose-dev.yml`, so Postgres and pgvector behave identically in all three places.

**Schema comes from `prisma migrate deploy`, not `metadata.create_all()`.** The SQLAlchemy models declare their enum types with `create_type=False` because Prisma owns them, so `create_all()` can't build the schema alone. Applying the real migrations also means tests run against exactly what production has.

## The `db` fixture

Wraps each test in a transaction that is **always rolled back**. Isolation without truncating — which matters because the local database holds a copy of production. Verified: 11 writing tests leave **zero** rows behind.

Rollback is skipped when the transaction is already aborted, otherwise every constraint test emits `SAWarning: transaction already deassociated`.

## Availability is handled deliberately

| | |
|---|---|
| no DB, local | **11 skipped** — contributors without Docker can still run the suite |
| no DB, `CI=true` | **11 errors** with a fix-it message |

A fixture that skips quietly in CI is worse than no fixture: the run still reports green on tests that never executed.

## Coverage

Eleven tests on the CAR-155 tables — status defaults, the idempotency-key constraint **CAR-116 depends on**, cascade deletes, relationship traversal, JSONB round-tripping with types intact (a float returning as a string would make confidence comparisons silently wrong), and stage ordering by `sequence` rather than insertion.

```
44 → 55 passed, 2 xfailed, still under 15s
```

## Next

With this in place, CAR-115 proper: remove the 13 module-level `db = next(get_db())` globals, thread sessions through service methods, and use a per-task context manager for background paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD