### PR TITLE
feat(db): add session_scope for work outside a request (CAR-115)

### DIFF
--- a/agents-api/app/db/session.py
+++ b/agents-api/app/db/session.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Generator
+from contextlib import contextmanager
+from typing import Generator, Iterator
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from app.core.config import settings
@@ -37,3 +38,28 @@ def get_db() -> Generator:
     finally:
         logger.debug("Closing database session")
         db.close()
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """A session for work that happens outside a request.
+
+    `get_db` is a FastAPI dependency: the session it yields is closed when the
+    response is sent. Most of this service's work is dispatched with
+    `BackgroundTasks` and therefore runs *after* that point, so a request-scoped
+    session would already be closed by the time it was used. Those paths open
+    their own session with this instead.
+
+    Deliberately does not commit on exit. The `*_db` helpers already commit
+    their own writes, and adding an implicit commit here would also commit work
+    a caller had decided to abandon. Rolling back on an exception and always
+    closing is the part that was missing.
+    """
+    session = SessionLocal()
+    try:
+        yield session
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/agents-api/tests/conftest.py
+++ b/agents-api/tests/conftest.py
@@ -12,7 +12,15 @@ would otherwise hand real credentials to the suite, and `load_dotenv()` in
 
 import os
 
-os.environ["DATABASE_URL"] = "postgresql://test:test@localhost:5432/agents_test"
+# CI provides TEST_DATABASE_URL; locally this is docker-compose-dev.yml.
+# The application's own engine is pointed at it too, so tests that exercise
+# app.db.session (rather than the `db` fixture) reach the same database.
+# Nothing connects at import - SQLAlchemy engines are lazy - so the hermetic
+# tests are unaffected.
+_TEST_DATABASE_URL = os.environ.setdefault(
+    "TEST_DATABASE_URL", "postgresql://postgres:secret@localhost:5434/postgres"
+)
+os.environ["DATABASE_URL"] = _TEST_DATABASE_URL
 os.environ["OPENAI_API_KEY"] = "sk-test-not-a-real-key"
 os.environ["REDIS_URL"] = "redis://localhost:6379/15"
 os.environ["API_KEY_SECRET"] = "test-secret"
@@ -125,9 +133,7 @@ def allow_loopback_check():
 # service container both work.
 
 # CI provides this; locally it defaults to docker-compose-dev.yml.
-TEST_DATABASE_URL = os.environ.get(
-    "TEST_DATABASE_URL", "postgresql://postgres:secret@localhost:5434/postgres"
-)
+TEST_DATABASE_URL = _TEST_DATABASE_URL
 
 
 @pytest.fixture(scope="session")

--- a/agents-api/tests/test_db_session.py
+++ b/agents-api/tests/test_db_session.py
@@ -1,0 +1,121 @@
+"""Tests for session lifecycle (CAR-115).
+
+The bug these exist to prevent: a single `db = next(get_db())` evaluated at
+import time and shared by every request, agent and background task for the
+lifetime of the process. That session is never closed, its identity map grows
+without bound, it is not safe under concurrency, and one failed transaction
+leaves it unusable for everything else.
+
+The failure mode is intermittent rather than immediate, which is exactly why it
+needs tests rather than a smoke check.
+"""
+
+import importlib
+import pkgutil
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm import Session
+
+import app as app_package
+from app.db.session import session_scope
+
+
+class Boom(Exception):
+    pass
+
+
+# --- session_scope ------------------------------------------------------------
+
+
+def test_yields_a_usable_session(db_engine):
+    with session_scope() as session:
+        assert isinstance(session, Session)
+        assert session.execute(text("select 1")).scalar() == 1
+
+
+def test_closes_the_session_on_exit(db_engine):
+    with session_scope() as session:
+        session.execute(text("select 1"))
+
+    # A closed session has released its connection back to the pool.
+    assert not session.in_transaction()
+
+
+def test_each_scope_gets_its_own_session(db_engine):
+    with session_scope() as first:
+        with session_scope() as second:
+            assert first is not second
+
+
+def test_an_exception_rolls_back_and_propagates(db_engine):
+    """A failed unit of work must not leave a half-applied transaction behind,
+    and must not swallow the error that caused it.
+    """
+    with pytest.raises(Boom):
+        with session_scope() as session:
+            session.execute(text("create temporary table car115_probe (id int)"))
+            raise Boom()
+
+    # The temporary table went with the rolled-back transaction.
+    with session_scope() as session:
+        exists = session.execute(text("select to_regclass('car115_probe') is not null")).scalar()
+        assert exists is False
+
+
+def test_a_failed_scope_does_not_poison_the_next_one(db_engine):
+    """The core problem with a shared module-level session: one bad transaction
+    left it aborted, so every later caller failed too with
+    "current transaction is aborted, commands ignored".
+    """
+    with pytest.raises(DBAPIError):
+        with session_scope() as session:
+            session.execute(text("select 1 / 0"))
+
+    with session_scope() as session:
+        assert session.execute(text("select 1")).scalar() == 1
+
+
+# --- no module-level sessions -------------------------------------------------
+
+
+def _app_modules():
+    """Every module under `app`, so a new one cannot quietly reintroduce this."""
+    for info in pkgutil.walk_packages(app_package.__path__, prefix="app."):
+        yield info.name
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "CAR-115 not finished: 12 modules still hold a process-wide session opened "
+        "at import. session_scope() now exists and is tested, but replacing the "
+        "globals is not a find-and-replace. Model instances are passed between "
+        "functions, so an object loaded under one session and written through "
+        "another raises InvalidRequestError - each background task needs one "
+        "session opened at its entry point and threaded down. This test goes "
+        "green when that lands."
+    ),
+)
+def test_no_module_holds_a_session_at_import_time():
+    """This is the acceptance criterion for CAR-115.
+
+    Importing a module must not open a database session. Any module-level
+    `db = next(get_db())` shows up here as an attribute that is a live Session.
+    """
+    offenders = []
+    for name in _app_modules():
+        try:
+            module = importlib.import_module(name)
+        except Exception:  # noqa: BLE001 - import errors are other tests' problem
+            continue
+        for attr in vars(module).values():
+            if isinstance(attr, Session):
+                offenders.append(name)
+                break
+
+    assert offenders == [], (
+        "These modules open a database session at import time, which is shared "
+        "process-wide and never closed: " + ", ".join(sorted(offenders))
+    )


### PR DESCRIPTION
First half of **CAR-115**: the session lifecycle primitive, plus the tests that define what "fixed" means. Replacing the 12 module-level globals follows in the next PR — see below for why that isn't mechanical.

## `session_scope()` is a context manager, not a dependency

The ticket says to thread `db: Session = Depends(get_db)` in from endpoints. **That would be wrong for most of this service.**

Nine endpoints dispatch through `BackgroundTasks`, so the work runs *after* the response is sent — by which point a `Depends(get_db)` session has already been closed. Those paths need to open their own.

It also **deliberately does not commit on exit**. The `*_db` helpers already commit their own writes (15 call sites); an implicit commit here would also commit work a caller had decided to abandon. Rollback-on-error and always-close is the part that was actually missing.

## Six tests pin the contract

Including the one that names the real-world symptom:

```python
def test_a_failed_scope_does_not_poison_the_next_one(...)
```

With a shared global session, one bad transaction left it aborted and every later caller failed with *"current transaction is aborted, commands ignored"*. That's the bug, reproduced.

## The acceptance criterion, as a test

`test_no_module_holds_a_session_at_import_time` walks every module under `app/` and asserts none holds a live `Session` after import. Currently **xfail(strict)**, naming all twelve offenders. It goes green on its own when the refactor lands — no one has to remember to flip it.

## Why the refactor isn't in this PR

I started it and hit something that changes its shape.

`update_location_coordinates(location)` takes a **model instance** and writes it via `update_location(location, db)`. That object is bound to whatever session loaded it. Today everything shares one global, so it always matches. With per-task sessions, an object loaded under one and written through another raises `InvalidRequestError: Object is already attached to session`.

So each background task needs **one session opened at its entry point and threaded down** — not each leaf opening its own. That's a real design constraint across 12 modules, and doing it half-carefully is how you get intermittent production failures rather than a red test.

```
55 → 60 passed, 3 xfailed, under 13s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD