### PR TITLE
refactor(agents-api): scope sessions in role, image storage and coordinates

### DIFF
--- a/agents-api/app/agents/location.py
+++ b/agents-api/app/agents/location.py
@@ -429,7 +429,7 @@ class LocationAgent:
 
                 # Trigger coordinates update as a background task
                 self._create_background_task(
-                    coordinates_service.update_location_coordinates(location)
+                    coordinates_service.update_location_coordinates(location.id)
                 )
 
             # Update the domain with the location

--- a/agents-api/app/services/coordinates.py
+++ b/agents-api/app/services/coordinates.py
@@ -1,15 +1,12 @@
 import logging
 
 from app.core.config import settings
-from app.db import get_db
 from app.db.models import Location
+from app.db.session import session_scope
 from app.utils.http_client import HTTPClient
 from app.utils.location_db import update_location
 
 logger = logging.getLogger(__name__)
-
-# Get a database session for the service
-db = next(get_db())
 
 
 class CoordinatesService:
@@ -40,29 +37,40 @@ class CoordinatesService:
         """Ensure sync client is closed when object is destroyed."""
         self.client.close()
 
-    async def update_location_coordinates(self, location: Location):
-        """
-        Updates the coordinates for a location using a geocoding service.
-        This is an async background task.
+    async def update_location_coordinates(self, location_id: str) -> None:
+        """Updates the coordinates for a location using a geocoding service.
+
+        Takes an id rather than a model instance, and loads it in its own
+        session. Both callers dispatch this as fire-and-forget work - one
+        through `_create_background_task` - so it can outlive the scope it was
+        started from. A session or a live instance handed in from there would
+        already be closed or detached by the time this ran.
         """
         try:
-            response = await self.client.aget_json(
-                f"{location.city},{location.country_code}&limit=1&appid={settings.GEOLOCATION_API_KEY}"
-            )
+            with session_scope() as db:
+                location = db.get(Location, location_id)
+                if location is None:
+                    logger.warning(f"Location {location_id} no longer exists")
+                    return
 
-            # If the response is empty, we return None
-            if not response or len(response) == 0:
-                return None
+                response = await self.client.aget_json(
+                    f"{location.city},{location.country_code}"
+                    f"&limit=1&appid={settings.GEOLOCATION_API_KEY}"
+                )
 
-            # Assumption that the first item is the one we want
-            # 99.999% of the time, it is
-            location_data = response[0]
-            location.latitude = location_data["lat"]
-            location.longitude = location_data["lon"]
+                # If the response is empty, we return None
+                if not response or len(response) == 0:
+                    return None
 
-            update_location(location, db)
+                # Assumption that the first item is the one we want
+                # 99.999% of the time, it is
+                location_data = response[0]
+                location.latitude = location_data["lat"]
+                location.longitude = location_data["lon"]
+
+                update_location(location, db)
         except Exception as e:
-            logger.error(f"Error updating coordinates for location {location.id}: {str(e)}")
+            logger.error(f"Error updating coordinates for location {location_id}: {str(e)}")
 
 
 coordinates_service = CoordinatesService()

--- a/agents-api/app/services/image_storage.py
+++ b/agents-api/app/services/image_storage.py
@@ -5,10 +5,8 @@ import cloudinary.exceptions
 import cloudinary.uploader
 
 from app.core.config import settings
-from app.db import get_db
+from app.db.session import session_scope
 from app.utils.alumni_db import find_all, update_alumni
-
-db = next(get_db())
 
 logger = logging.getLogger(__name__)
 
@@ -23,13 +21,17 @@ class ImageStorageService:
         )
 
     def upload_all_alumni_profile_pictures(self):
+        """Upload all alumni profile pictures to Cloudinary.
+
+        Self-contained, so it opens its own session: the Alumni rows are both
+        loaded and written here, which keeps them attached to one session.
         """
-        Upload all alumni profile pictures to Cloudinary.
-        """
-        alumni = find_all(db)
-        logger.info(f"Found {len(alumni)} alumni with profile pictures to upload")
-        for alumni in alumni:
-            if alumni.profile_picture_url:
+        with session_scope() as db:
+            alumni_list = find_all(db)
+            logger.info(f"Found {len(alumni_list)} alumni with profile pictures to upload")
+            for alumni in alumni_list:
+                if not alumni.profile_picture_url:
+                    continue
                 try:
                     new_profile_picture_url = self.upload_image(
                         alumni.profile_picture_url, alumni.id
@@ -55,9 +57,7 @@ class ImageStorageService:
             The secure URL of the uploaded image, or None if upload fails.
         """
         try:
-            upload_result = cloudinary.uploader.upload(
-                image_url, public_id=public_id, timeout=60
-            )
+            upload_result = cloudinary.uploader.upload(image_url, public_id=public_id, timeout=60)
             return upload_result["secure_url"]
         except (cloudinary.exceptions.Error, Exception) as e:
             logger.error(f"Failed to upload image {image_url}: {str(e)}")

--- a/agents-api/app/services/location.py
+++ b/agents-api/app/services/location.py
@@ -89,7 +89,7 @@ class LocationService:
         """
         Get the coordinates of a city from the Geocoding API and update the location object
         """
-        await coordinates_service.update_location_coordinates(location)
+        await coordinates_service.update_location_coordinates(location.id)
 
 
 location_service = LocationService()

--- a/agents-api/app/services/role.py
+++ b/agents-api/app/services/role.py
@@ -1,9 +1,11 @@
 import asyncio
 import logging
 
+from sqlalchemy.orm import Session
+
 from app.agents.location import location_agent
 from app.db.models import Role, RoleRaw, SeniorityLevel
-from app.db.session import get_db
+from app.db.session import session_scope
 from app.schemas.linkedin import ExperienceBase
 from app.schemas.location import LocationType, RoleLocationInput
 from app.schemas.role import RoleResolveLocationParams
@@ -19,15 +21,31 @@ from app.utils.role_db import (
 
 logger = logging.getLogger(__name__)
 
-# Get a database session for the service
-db = next(get_db())
-
 
 class RoleService:
+    """Entry points open a session; the work takes one as a parameter.
+
+    These methods are dispatched with BackgroundTasks, so they run after the
+    response has been sent and cannot borrow a request-scoped session. One
+    session per unit of work also keeps the Role objects loaded here attached
+    to the session that writes them.
+    """
+
     async def resolve_role_location(self, params: RoleResolveLocationParams) -> None:
-        """
-        Resolves the location of the roles
-        """
+        """Resolves the location of the roles."""
+        with session_scope() as db:
+            await self._resolve_role_location(params, db)
+
+    async def resolve_role_location_for_alumni(self, alumni_ids: str) -> None:
+        """Resolves the location of the roles for a given alumni."""
+        with session_scope() as db:
+            roles = get_roles_by_alumni_id(alumni_ids, db)
+            role_ids_str = ",".join(role.id for role in roles)
+            # Reuses the same session rather than opening a second one for what
+            # is a single unit of work.
+            await self._resolve_role_location(RoleResolveLocationParams(role_ids=role_ids_str), db)
+
+    async def _resolve_role_location(self, params: RoleResolveLocationParams, db: Session) -> None:
         role_ids = params.role_ids
 
         roles: list[Role] = []
@@ -79,15 +97,6 @@ class RoleService:
 
             if i + batch_size < len(roles):
                 await asyncio.sleep(0.5)
-
-    async def resolve_role_location_for_alumni(self, alumni_ids: str) -> None:
-        """
-        Resolves the location of the roles for a given alumni
-        """
-        roles = get_roles_by_alumni_id(alumni_ids, db)
-        role_ids = [role.id for role in roles]
-        role_ids_str = ",".join(role_ids)
-        await self.resolve_role_location(RoleResolveLocationParams(role_ids=role_ids_str))
 
     async def parse_role(
         self,


### PR DESCRIPTION
Three of the twelve modules holding a process-wide session opened at import. Each is independent, so this lands without a half-state — the xfail acceptance test stays red until the remaining nine follow.

## Three modules, three different shapes

**`RoleService`** — both public methods are `BackgroundTasks` entry points, so they open a session and delegate to a private method that takes one. `resolve_role_location_for_alumni` used to call the other *public* method, which would now open a second session for what is one unit of work; it passes its own down instead.

**`ImageStorageService`** — self-contained. It loads and writes the same `Alumni` rows, so one scope around the whole loop keeps them attached to a single session.

**`CoordinatesService`** — needed a different shape entirely, and this is the interesting one.

## The fire-and-forget problem

It was taking a live `Location` instance. Both callers dispatch it as fire-and-forget — the one in agents/location.py goes through `_create_background_task` — so **it can outlive the scope it was started from**. Neither a session nor an attached instance survives that:

- pass the session → closed by the time it runs
- pass the instance → detached, or bound to a session that's gone

So it now takes an **id** and loads the row in its own session. As a side effect it handles the location having been deleted in between, rather than assuming it's still there.

This is the concrete version of the hazard flagged on CAR-115: the replacement is per-call-site design, not find-and-replace. Three modules, three different correct answers.

## Verification

```
60 passed, 3 xfailed        unchanged
ruff app/                   51            unchanged baseline
remaining globals           12 → 9
```

No behaviour change intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD
