### PR TITLE
refactor(agents-api): scope sessions in the location endpoint and two agents

### DIFF
--- a/agents-api/app/agents/job_classification.py
+++ b/agents-api/app/agents/job_classification.py
@@ -20,7 +20,7 @@ from tenacity import (
 )
 
 from app.core.config import settings
-from app.db import get_db
+from app.db.session import session_scope
 from app.schemas.job_classification import (
     JobClassificationAgentState,
     JobClassificationRoleInput,
@@ -40,9 +40,6 @@ from app.utils.prompts import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Get a database session for the agent
-db = next(get_db())
 
 json_schema = {
     "type": "object",
@@ -235,7 +232,10 @@ class JobClassificationAgent:
             ]
 
             if updates:
-                await update_role_with_classifications_batch(db, updates, DEFAULT_ACTION_BY)
+                # Loads nothing and writes in one go, so a scope of its own is
+                # enough - no instance crosses a session boundary here.
+                with session_scope() as db:
+                    await update_role_with_classifications_batch(db, updates, DEFAULT_ACTION_BY)
 
         except Exception as e:
             logger.error(f"Error in batch update classifications: {str(e)}")

--- a/agents-api/app/agents/seniority.py
+++ b/agents-api/app/agents/seniority.py
@@ -7,6 +7,7 @@ from langchain_core.tools import Tool
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.prebuilt import ToolNode
+from sqlalchemy.orm import Session
 from tenacity import (
     before_sleep_log,
     retry,
@@ -15,8 +16,8 @@ from tenacity import (
 )
 
 from app.core.config import settings
-from app.db import get_db
 from app.db.models import SeniorityLevel
+from app.db.session import session_scope
 from app.schemas.seniority import BatchSeniorityInput, SeniorityAgentState
 from app.utils.prompts import (
     SENIORITY_CLASSIFICATION_PROMPT,
@@ -26,9 +27,6 @@ from app.utils.role_db import get_role_by_id, update_role
 
 # Configure logging
 logger = logging.getLogger(__name__)
-
-# Get a database session for the service
-db = next(get_db())
 
 
 json_schema = {
@@ -173,8 +171,15 @@ Schema:
             raise e
 
     def update_roles_with_seniority(self, state: SeniorityAgentState) -> SeniorityAgentState:
-        for entry in state["parsed_seniority_results"]:
+        # One session for the whole batch: each Role is loaded and written here,
+        # so it stays attached to the session that saves it.
+        with session_scope() as db:
+            return self._update_roles_with_seniority(state, db)
 
+    def _update_roles_with_seniority(
+        self, state: SeniorityAgentState, db: Session
+    ) -> SeniorityAgentState:
+        for entry in state["parsed_seniority_results"]:
             role_id = entry["role_id"]
             try:
                 role = get_role_by_id(role_id, db)
@@ -184,7 +189,7 @@ Schema:
 
                 new_seniority = SeniorityLevel[entry["seniority"]]
                 role.seniority_level = new_seniority
-                
+
                 role.metadata_ = {
                     **(role.metadata_ or {}),
                     "seniority_classification": {

--- a/agents-api/app/api/endpoints/location.py
+++ b/agents-api/app/api/endpoints/location.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.schemas.location import (
@@ -13,8 +14,6 @@ from app.utils.alumni_db import find_all
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-db = next(get_db())
 
 
 @router.post(
@@ -50,7 +49,9 @@ async def resolve_role_location(
     status_code=status.HTTP_201_CREATED,
 )
 async def resolve_alumni_location(
-    background_tasks: BackgroundTasks, params: ResolveAlumniLocationParams = Depends()
+    background_tasks: BackgroundTasks,
+    params: ResolveAlumniLocationParams = Depends(),
+    db: Session = Depends(get_db),
 ):
     """
     Triggers the agent to resolve the location of an alumni.


### PR DESCRIPTION
Three more of the twelve module-level sessions, leaving **six**.

| module | shape | why |
|---|---|---|
| `endpoints/location.py` | `Depends(get_db)` | the query runs **during** the request, before any background task is dispatched — the one place the ticket's original DI prescription is right |
| `agents/job_classification.py` | own scope | write-only, single call; nothing crosses a session boundary |
| `agents/seniority.py` | own scope + private method taking `db` | loads each `Role` and writes it back in the same loop, so one session for the batch keeps them attached |

Splitting the seniority agent into `update_roles_with_seniority` / `_update_roles_with_seniority` also makes the update logic testable with the `db` fixture without going through langgraph — worth having when CAR-103 rewrites these agents.

```
60 passed, 3 xfailed     unchanged
ruff baseline 51         unchanged
globals: 9 → 6
```

Remaining six are the entangled ones: `agents/location.py` (12 usages, 518 lines), `services/linkedin.py` (14), plus company, location, seniority and job_classification services — several of which call each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD