### PR TITLE
refactor(agents-api): scope sessions in the seniority, classification and location services

### DIFF
--- a/agents-api/app/services/job_classification.py
+++ b/agents-api/app/services/job_classification.py
@@ -3,8 +3,8 @@ import logging
 import math
 
 from app.agents.job_classification import job_classification_agent
-from app.db import get_db
 from app.db.models import Alumni
+from app.db.session import session_scope
 from app.schemas.job_classification import (
     AlumniJobClassificationParams,
 )
@@ -14,8 +14,6 @@ from app.utils.role_db import get_extended_roles_by_alumni_id
 
 logger = logging.getLogger(__name__)
 
-db = next(get_db())
-
 
 class JobClassificationService:
     def __init__(self):
@@ -24,11 +22,12 @@ class JobClassificationService:
 
     async def classify_roles_for_alumni(self, alumni_id: str):
         try:
-            input_data = get_extended_roles_by_alumni_id(alumni_id, db)
-            if not input_data.roles:
-                return
-
-            roles = input_data.roles
+            # Its own session: these run concurrently under asyncio.gather.
+            with session_scope() as db:
+                input_data = get_extended_roles_by_alumni_id(alumni_id, db)
+                if not input_data.roles:
+                    return
+                roles = input_data.roles
 
             for i in range(0, len(roles), self.MAX_CONCURRENT):
                 batch = roles[i : i + self.MAX_CONCURRENT]
@@ -47,27 +46,23 @@ class JobClassificationService:
         Request the classification of the roles of the alumni
         """
         alumni_ids = params.alumni_ids
-        alumni: list[Alumni] = []
 
-        if alumni_ids:
-            alumni = find_by_ids(alumni_ids.split(","), db)
-        else:
-            alumni = find_all(db)
-
-        alumni = list(set(alumni))
-        logger.info(f"Going to update {len(alumni)} alumni")
-
-        for i in range(0, len(alumni), self.BATCH_SIZE):
-            batch = alumni[i : i + self.BATCH_SIZE]
-            batch_no = i // self.BATCH_SIZE + 1
-            logger.info(
-                f"Processing batch {batch_no} of {math.ceil(len(alumni) / self.BATCH_SIZE)}"
+        # Session held for the lookup only - the batches below are minutes of
+        # LLM calls and should not pin a connection.
+        with session_scope() as db:
+            alumni: list[Alumni] = (
+                find_by_ids(alumni_ids.split(","), db) if alumni_ids else find_all(db)
             )
+            ids = list({al.id for al in alumni})
 
-            tasks = [
-                asyncio.create_task(self.classify_roles_for_alumni(al.id))
-                for al in batch
-            ]
+        logger.info(f"Going to update {len(ids)} alumni")
+
+        for i in range(0, len(ids), self.BATCH_SIZE):
+            batch = ids[i : i + self.BATCH_SIZE]
+            batch_no = i // self.BATCH_SIZE + 1
+            logger.info(f"Processing batch {batch_no} of {math.ceil(len(ids) / self.BATCH_SIZE)}")
+
+            tasks = [asyncio.create_task(self.classify_roles_for_alumni(aid)) for aid in batch]
             await asyncio.gather(*tasks)
 
             if i + self.BATCH_SIZE < len(alumni):

--- a/agents-api/app/services/location.py
+++ b/agents-api/app/services/location.py
@@ -2,8 +2,8 @@ import asyncio
 import logging
 
 from app.agents.location import location_agent
-from app.db import get_db
 from app.db.models import Location, Role
+from app.db.session import session_scope
 from app.schemas.location import (
     LocationType,
     ResolveRoleLocationParams,
@@ -21,7 +21,6 @@ from app.utils.role_db import (
 logger = logging.getLogger(__name__)
 
 # Get a database session for the service
-db = next(get_db())
 
 
 class LocationService:
@@ -31,58 +30,63 @@ class LocationService:
         """
         role_ids = params.role_ids
 
-        roles: list[Role] = []
+        # Everything the database is needed for happens here. The batches below
+        # sleep 60s between them, so holding the session open across the whole
+        # run would pin a connection for the duration.
+        with session_scope() as db:
+            roles: list[Role] = (
+                get_roles_by_ids(role_ids.split(","), db) if role_ids else get_all_roles(db)
+            )
 
-        if role_ids:
-            role_ids = role_ids.split(",")
-            roles = get_roles_by_ids(role_ids, db)
-        else:
-            roles = get_all_roles(db)
+            # just making sure the user was not dumb and provided duplicate role IDs
+            # and newsflash, that user is me :))
+            roles = list(set(roles))
 
-        # just making sure the user was not dumb and provided duplicate role IDs
-        # and newsflash, that user is me :))
-        roles = list(set(roles))
-
-        batch_size = 300
-        for i in range(0, len(roles), batch_size):
-            logger.info(f"Processing batch {i // batch_size + 1} of {len(roles) // batch_size}")
-            
-            batch = roles[i : i + batch_size]
-
-            tasks = []
-            for role in batch:
+            inputs: list[RoleLocationInput] = []
+            for role in roles:
                 role_raw = get_role_raw_by_id(role.id, db)
-                location = role_raw.location
-
-                if not location:
+                # A role with no raw row, or no free-text location on it, is not
+                # something the agent can resolve. Previously the former raised
+                # AttributeError and took the whole batch down.
+                if not role_raw or not role_raw.location:
                     continue
-
-                loc_input = RoleLocationInput(
-                    type=LocationType.ROLE,
-                    role_id=role.id,
-                    location=role_raw.location,
+                inputs.append(
+                    RoleLocationInput(
+                        type=LocationType.ROLE,
+                        role_id=role.id,
+                        location=role_raw.location,
+                    )
                 )
 
-                task = asyncio.create_task(
+        batch_size = 300
+        for i in range(0, len(inputs), batch_size):
+            logger.info(f"Processing batch {i // batch_size + 1} of {len(inputs) // batch_size}")
+
+            batch = inputs[i : i + batch_size]
+
+            tasks = [
+                asyncio.create_task(
                     with_pipeline_timeout(
                         location_agent.process_location(loc_input),
                         step="location.process_location",
                     )
                 )
-                tasks.append(task)
+                for loc_input in batch
+            ]
 
             await asyncio.gather(*tasks)
 
-            if i + batch_size < len(roles):
+            if i + batch_size < len(inputs):
                 await asyncio.sleep(60)
 
     async def resolve_role_location_for_alumni(self, alumni_id: str) -> None:
         """
         Resolves the location of the roles for a given alumni
         """
-        roles = get_roles_by_alumni_id(alumni_id, db)
-        role_ids = [role.id for role in roles]
-        role_ids_str = ",".join(role_ids)
+        with session_scope() as db:
+            roles = get_roles_by_alumni_id(alumni_id, db)
+            role_ids_str = ",".join(role.id for role in roles)
+
         await self.request_role_location(ResolveRoleLocationParams(role_ids=role_ids_str))
 
     async def update_location_coordinates(self, location: Location):

--- a/agents-api/app/services/seniority.py
+++ b/agents-api/app/services/seniority.py
@@ -1,12 +1,11 @@
 import asyncio
 import logging
-import math
 from datetime import datetime
 from typing import List
 
 from app.agents.seniority import seniority_agent
 from app.db.models import Alumni, Role
-from app.db.session import get_db
+from app.db.session import session_scope
 from app.schemas.seniority import AlumniSeniorityParams, BatchSeniorityInput, RoleSeniorityInput
 from app.utils.alumni_db import find_all, find_by_ids
 from app.utils.pipeline_timeout import with_pipeline_timeout
@@ -15,7 +14,6 @@ from app.utils.role_db import get_roles_by_alumni_id
 logger = logging.getLogger(__name__)
 
 # Get a database session for the service
-db = next(get_db())
 
 
 class SeniorityService:
@@ -139,12 +137,14 @@ class SeniorityService:
         Process all roles for an alumni as a batch
         """
         try:
-            roles = get_roles_by_alumni_id(alumni_id, db)
-            if not roles:
-                return
-
-            batch_input = self._prepare_batch_input(alumni_id, roles)
-        
+            # Its own session: these run concurrently under asyncio.gather, and
+            # sharing one across them is the same thread-safety problem as the
+            # module-level global, only smaller.
+            with session_scope() as db:
+                roles = get_roles_by_alumni_id(alumni_id, db)
+                if not roles:
+                    return
+                batch_input = self._prepare_batch_input(alumni_id, roles)
 
             async with self.semaphore:
                 await with_pipeline_timeout(
@@ -160,28 +160,25 @@ class SeniorityService:
         Request the classification of seniority of the roles of the alumni
         """
         alumni_ids = params.alumni_ids
-        alumni: list[Alumni] = []
 
-        if alumni_ids:
-            alumni = find_by_ids(alumni_ids.split(","), db)
-        else:
-            alumni = find_all(db)
-
-        alumni = list(set(alumni))
-        # logger.info(f"Going to process roles for {len(alumni)} alumni")
+        # The session is held for the lookup only. Keeping it open across the
+        # batches below would pin a connection for the whole run, which is
+        # minutes of LLM calls, not milliseconds of query.
+        with session_scope() as db:
+            alumni: list[Alumni] = (
+                find_by_ids(alumni_ids.split(","), db) if alumni_ids else find_all(db)
+            )
+            ids = list({al.id for al in alumni})
 
         # Process in batches
-        for i in range(0, len(alumni), self.BATCH_SIZE):
-            batch = alumni[i : i + self.BATCH_SIZE]
+        for i in range(0, len(ids), self.BATCH_SIZE):
+            batch = ids[i : i + self.BATCH_SIZE]
             batch_no = i // self.BATCH_SIZE + 1
             # logger.info(
-            #     f"Processing batch {batch_no} of {math.ceil(len(alumni) / self.BATCH_SIZE)}"
+            #     f"Processing batch {batch_no} of {math.ceil(len(ids) / self.BATCH_SIZE)}"
             # )
-            
-            tasks = [
-                asyncio.create_task(self.process_alumni_roles(al.id))
-                for al in batch
-            ]
+
+            tasks = [asyncio.create_task(self.process_alumni_roles(aid)) for aid in batch]
             await asyncio.gather(*tasks)
 
 


### PR DESCRIPTION
Three more of the twelve, leaving **three**: linkedin, company, and the location agent.

## These three share a shape the earlier ones did not

Each has an entry point that loads a list of alumni or roles, then fans out with `asyncio.gather`. Two consequences:

**Per-task sessions, not a shared one.** The fanned-out coroutines run concurrently. Handing them one session would recreate exactly the bug this ticket exists to fix — just scoped to a request instead of the process.

**The session is held for the lookup only.** Previously the query and the work shared a scope, pinning a pool connection for the whole run. These runs are *minutes* of LLM calls, and `request_role_location` sleeps **60 seconds** between batches. Now the lookup resolves to plain ids or Pydantic inputs, the session closes, and the async work proceeds without holding one.

That second point matters beyond tidiness: `pool_size=20` with runs that hold a connection for minutes is how you exhaust a pool with very little concurrency.

## One deliberate behaviour change

`request_role_location` did `role_raw.location` without checking `get_role_raw_by_id` returned anything — so a role with no raw row raised `AttributeError` and took **the whole batch** down. Those roles are now skipped, which is already what the surrounding code did for a role whose location was empty.

Called out explicitly because every other commit in this series has been behaviour-preserving.

```
60 passed, 3 xfailed     unchanged
ruff baseline 51 → 50    restructuring removed a long line
globals: 6 → 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD