### PR TITLE
refactor(agents-api): remove the last module-level sessions (CAR-115)

### DIFF
--- a/agents-api/app/agents/location.py
+++ b/agents-api/app/agents/location.py
@@ -14,6 +14,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.graph import END, START, StateGraph
 from langgraph.prebuilt import ToolNode
 from redis import Redis
+from sqlalchemy.orm import Session
 from tenacity import (
     before_sleep_log,
     retry,
@@ -22,8 +23,8 @@ from tenacity import (
 )
 
 from app.core.config import settings
-from app.db import get_db
 from app.db.models import Location
+from app.db.session import session_scope
 from app.schemas.location import LocationAgentState, LocationInput, LocationResult, LocationType
 from app.services.coordinates import coordinates_service
 from app.utils.alumni_db import find_by_id, update_alumni
@@ -41,9 +42,6 @@ from app.utils.role_db import get_role_by_id, update_role
 logger = logging.getLogger(__name__)
 
 DEFAULT_UPDATED_BY = "location-agent"
-
-# Get a database session for the service
-db = next(get_db())
 
 # JSON schema for location resolution
 geo_resolution_schema = {
@@ -129,6 +127,7 @@ rate_limiter = TokenRateLimiter(
     redis_client=Redis.from_url(settings.REDIS_URL),
     distributed_key="openai_location_agent_rate_limiter",
 )
+
 
 # Helper to estimate token usage
 @lru_cache(maxsize=1)
@@ -270,17 +269,22 @@ class LocationAgent:
 
         try:
             # here, we'll fetch locations for the resolved country code
-            db_locations = get_locations_by_country_code(state["resolved_country_code"], db)
-            state["db_locations"] = [
-                LocationResult(
-                    id=location.id,
-                    city=location.city,
-                    country=location.country,
-                    country_code=location.country_code,
-                    is_country_only=location.is_country_only,
-                )
-                for location in db_locations
-            ]
+            # The conversion to LocationResult stays inside the scope: reading
+            # attributes off a detached instance happens to work while they are
+            # already loaded, but it is one lazy relationship away from a
+            # DetachedInstanceError.
+            with session_scope() as db:
+                db_locations = get_locations_by_country_code(state["resolved_country_code"], db)
+                state["db_locations"] = [
+                    LocationResult(
+                        id=location.id,
+                        city=location.city,
+                        country=location.country,
+                        country_code=location.country_code,
+                        is_country_only=location.is_country_only,
+                    )
+                    for location in db_locations
+                ]
         except Exception as e:
             logger.error(f"Error fetching locations: {str(e)}")
             state["error"] = str(e)
@@ -387,9 +391,19 @@ class LocationAgent:
         return await self.resolve_location_with_retry(state)
 
     async def update_locations(self, states: List[LocationAgentState]) -> List[LocationAgentState]:
+        """Update locations in batch.
+
+        One session for the whole batch, not one per state. `seen` caches
+        Location instances across iterations to avoid re-querying, and those
+        instances are only valid within the session that loaded them - a
+        per-state session would hand the next iteration a detached object.
         """
-        Update locations in batch
-        """
+        with session_scope() as db:
+            return await self._update_locations(states, db)
+
+    async def _update_locations(
+        self, states: List[LocationAgentState], db: Session
+    ) -> List[LocationAgentState]:
         seen: dict[tuple, Location] = {}
         for state in states:
             if not state.get("location_result"):

--- a/agents-api/app/services/company.py
+++ b/agents-api/app/services/company.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 from app.agents.location import location_agent
 from app.core.config import settings
-from app.db import get_db
 from app.db.models import Company
+from app.db.session import session_scope
 from app.schemas.company import CompanyUpdateParams
 from app.schemas.linkedin import LinkedInCompanyResponse, convert_to_linkedin_company_response
 from app.schemas.location import CompanyLocationInput, LocationType
@@ -27,7 +27,6 @@ from app.utils.pipeline_timeout import with_pipeline_timeout
 logger = logging.getLogger(__name__)
 
 # Get a database session for the service
-db = next(get_db())
 
 
 class CompanyService:
@@ -103,41 +102,40 @@ class CompanyService:
         company_ids = params.company_ids
         # logger.info(f"Requesting company update for {company_ids}")
 
-        companies: list[Company] = []
+        # Session held for the lookup only. The batches below are network calls
+        # to BrightData with a delay between them, and each task opens its own
+        # session anyway.
+        with session_scope() as db:
+            companies: list[Company] = (
+                get_companies_by_ids(company_ids.split(","), db)
+                if company_ids
+                else get_all_companies(db)
+            )
+            # just making sure the user was not dumb and provided duplicate company IDs
+            # and newsflash, that user is me :))
+            targets = list({(c.id, c.linkedin_url) for c in companies})
 
-        if company_ids:
-            company_ids = company_ids.split(",")
-            companies = get_companies_by_ids(company_ids, db)
-        else:
-            companies = get_all_companies(db)
-
-        # just making sure the user was not dumb and provided duplicate company IDs
-        # and newsflash, that user is me :))
-        companies = list(set(companies))
-
-        # logger.info(f"Going to update {len(companies)} companies")
+        # logger.info(f"Going to update {len(targets)} companies")
 
         # Process in batches of 10 to avoid overwhelming the system
         batch_size = 10
-        for i in range(0, len(companies), batch_size):
-            batch = companies[i : i + batch_size]
+        for i in range(0, len(targets), batch_size):
+            batch = targets[i : i + batch_size]
             # logger.info(
             #    f"Processing batch {i // batch_size + 1} of {(len(companies) + batch_size - 1) // batch_size} ({len(batch)} companies)"
             # )
 
             # Create and track tasks for this batch
-            tasks = []
-            for company in batch:
-                task = asyncio.create_task(
-                    self.extract_company_data(company.linkedin_url, company.id)
-                )
-                tasks.append(task)
+            tasks = [
+                asyncio.create_task(self.extract_company_data(linkedin_url, company_id))
+                for company_id, linkedin_url in batch
+            ]
 
             # Wait for all tasks in this batch to complete
             await asyncio.gather(*tasks)
 
             # Small delay between batches to prevent rate limiting
-            if i + batch_size < len(companies):
+            if i + batch_size < len(targets):
                 await asyncio.sleep(1)
 
     async def extract_company_data(
@@ -242,9 +240,10 @@ class CompanyService:
 
         industry_id = DEFAULT_INDUSTRY_ID
         if company_response.industries:
-            industry = get_industry_by_name(company_response.industries, db)
-            if industry:
-                industry_id = industry.id
+            with session_scope() as db:
+                industry = get_industry_by_name(company_response.industries, db)
+                if industry:
+                    industry_id = industry.id
 
         company = Company(
             id=company_id,
@@ -264,8 +263,10 @@ class CompanyService:
             company.levels_fyi_url = levels_fyi_url
 
         try:
-            # Update the company
-            update_company(company, db)
+            # `company` is constructed here rather than loaded, so it is not
+            # attached to any session and can be written through a fresh one.
+            with session_scope() as db:
+                update_company(company, db)
 
             # Now that the company is updated, trigger location processing
             if company_response.headquarters and company_response.country_code:

--- a/agents-api/app/services/linkedin.py
+++ b/agents-api/app/services/linkedin.py
@@ -3,10 +3,12 @@ import logging
 from datetime import datetime
 from typing import List, Optional
 
+from sqlalchemy.orm import Session
+
 from app.agents.location import location_agent
 from app.core.config import settings
-from app.db import get_db
 from app.db.models import Alumni, Company
+from app.db.session import session_scope
 from app.schemas.job_classification import AlumniJobClassificationParams
 from app.schemas.linkedin import (
     LinkedInProfileResponse,
@@ -22,7 +24,6 @@ from app.utils.alumni_db import (
     delete_profile_data,
     find_all,
     find_by_id,
-    find_by_ids,
     update_alumni,
 )
 from app.utils.company_db import get_company_by_linkedin_url, insert_company
@@ -36,7 +37,6 @@ from app.utils.role_db import create_role, create_role_raw
 logger = logging.getLogger(__name__)
 
 # Get a database session for the service
-db = next(get_db())
 
 
 class LinkedInService:
@@ -95,13 +95,14 @@ class LinkedInService:
         """
         # logger.info(f"Extracting LinkedIn data for {alumni_id}")
 
-        # Get the alumni from the database
-        alumni = find_by_id(alumni_id, db)
-        if not alumni or not alumni.linkedin_url:
-            # logger.error(f"Alumni with id {alumni_id} not found or has no LinkedIn URL")
-            return
-
-        profile_url = alumni.linkedin_url
+        # Session held for the lookup only - the API call and processing below
+        # take far longer than the query.
+        with session_scope() as db:
+            alumni = find_by_id(alumni_id, db)
+            if not alumni or not alumni.linkedin_url:
+                # logger.error(f"Alumni with id {alumni_id} not found or has no LinkedIn URL")
+                return
+            profile_url = alumni.linkedin_url
 
         try:
             self.client.set_headers(
@@ -129,6 +130,36 @@ class LinkedInService:
         self,
         profile_data: LinkedInProfileResponse,
         alumni_id: str,
+    ) -> None:
+        # Uploading to Cloudinary needs no session, so it happens before one is
+        # opened rather than holding a pool connection during the upload.
+        profile_picture_url = None
+        if profile_data.profile_pic_url:
+            profile_picture_url = image_storage_service.upload_image(
+                profile_data.profile_pic_url, alumni_id
+            )
+
+        # One session for the whole unit of work: the Company and Role rows are
+        # created and written here, so they stay attached to the session that
+        # persists them.
+        with session_scope() as db:
+            await self._persist_profile_data(profile_data, alumni_id, profile_picture_url, db)
+
+        # Offloaded after the session closes - these are fire-and-forget and
+        # must not hold a connection.
+        self._create_background_task(
+            job_classification_service.request_alumni_classification(
+                params=AlumniJobClassificationParams(alumni_ids=alumni_id)
+            )
+        )
+        self._create_background_task(location_service.resolve_role_location_for_alumni(alumni_id))
+
+    async def _persist_profile_data(
+        self,
+        profile_data: LinkedInProfileResponse,
+        alumni_id: str,
+        profile_picture_url: Optional[str],
+        db: Session,
     ) -> None:
         # First, let's parse the roles, to understand if we need to extract company data
         for role in profile_data.experiences:
@@ -200,12 +231,6 @@ class LinkedInService:
 
             else:
                 location_id = location.id
-        # Let's upload their picture to cloudinary
-        profile_picture_url = None
-        if profile_data.profile_pic_url:
-            profile_picture_url = image_storage_service.upload_image(
-                profile_data.profile_pic_url, alumni_id
-            )
         # Update the alumni table (Alumni was already created by our backend :))) )
         update_alumni(
             Alumni(
@@ -215,17 +240,6 @@ class LinkedInService:
             ),
             db,
         )
-
-        # We'll now offload the role classification to a background task, using the agent
-        # Note that we do NOT wait for this to finish, as it can take a while
-        self._create_background_task(
-            job_classification_service.request_alumni_classification(
-                params=AlumniJobClassificationParams(alumni_ids=alumni_id)
-            )
-        )
-
-        # We'll also use the location agent to update the alumni location
-        self._create_background_task(location_service.resolve_role_location_for_alumni(alumni_id))
 
     async def update_profile_data(
         self,
@@ -242,7 +256,11 @@ class LinkedInService:
         """
         try:
             # Get alumni from database based on whether specific IDs were provided
-            ids = alumni_ids if alumni_ids else [alumni.id for alumni in find_all(db)]
+            if alumni_ids:
+                ids = alumni_ids
+            else:
+                with session_scope() as db:
+                    ids = [alumni.id for alumni in find_all(db)]
 
             results = []
             for i in range(0, len(ids), batch_size):
@@ -271,26 +289,28 @@ class LinkedInService:
         """Process a single alumni profile."""
         try:
             # Delete existing data before extraction
-            delete_profile_data(alumni_id, db)
+            with session_scope() as db:
+                delete_profile_data(alumni_id, db)
 
             # Extract new data
             await self.extract_profile_data(alumni_id)
             return True
         except Exception as e:
             logger.error(f"Error processing alumni {alumni_id}: {str(e)}")
-            alumni = find_by_id(alumni_id, db)
-            existing_metadata = alumni.metadata_ or {}
+            with session_scope() as db:
+                alumni = find_by_id(alumni_id, db)
+                existing_metadata = alumni.metadata_ or {} if alumni else {}
 
-            error_info = {
-                "linkedin_error": {
-                    "message": str(e),
-                    "timestamp": datetime.now().isoformat(),
-                    "type": e.__class__.__name__,
+                error_info = {
+                    "linkedin_error": {
+                        "message": str(e),
+                        "timestamp": datetime.now().isoformat(),
+                        "type": e.__class__.__name__,
+                    }
                 }
-            }
-            updated_metadata = {**existing_metadata, **error_info}
+                updated_metadata = {**existing_metadata, **error_info}
 
-            update_alumni(Alumni(id=alumni_id, metadata_=updated_metadata), db)
+                update_alumni(Alumni(id=alumni_id, metadata_=updated_metadata), db)
             return False
 
 

--- a/agents-api/tests/test_db_session.py
+++ b/agents-api/tests/test_db_session.py
@@ -86,18 +86,6 @@ def _app_modules():
         yield info.name
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "CAR-115 not finished: 12 modules still hold a process-wide session opened "
-        "at import. session_scope() now exists and is tested, but replacing the "
-        "globals is not a find-and-replace. Model instances are passed between "
-        "functions, so an object loaded under one session and written through "
-        "another raises InvalidRequestError - each background task needs one "
-        "session opened at its entry point and threaded down. This test goes "
-        "green when that lands."
-    ),
-)
 def test_no_module_holds_a_session_at_import_time():
     """This is the acceptance criterion for CAR-115.
 


### PR DESCRIPTION
**Completes CAR-115.** No module under `app/` opens a database session at import any more, and `test_no_module_holds_a_session_at_import_time` is no longer xfail — it went green on its own, which is what strict xfail is for.

```
globals: 12 → 0
61 passed, 2 xfailed     (the 2 remaining are the agent missing-return bugs, waiting on CAR-103)
ruff baseline 50 → 49
```

## The three hardest ones

**`services/linkedin.py`** — `process_profile_data` becomes a scope around a private `_persist_profile_data`, since the `Company` and `Role` rows it creates must stay attached to the session that writes them. The Cloudinary upload is hoisted *above* the scope and the two fire-and-forget follow-ups moved *below* it, so neither an image upload nor a background task holds a pool connection. `process_single_alumni` takes two independent scopes — the delete, and on failure the metadata write — because an exception in between must not leave one open.

**`services/company.py`** — the batch lookup resolves to `(id, url)` tuples and the session closes before the BrightData calls. `update_company` writes through a fresh session, which is safe *precisely because* that `Company` is constructed rather than loaded, so it's attached to nothing.

**`agents/location.py`** — `update_locations` needs **one session for the whole batch**, not one per state: `seen` caches `Location` instances across iterations, and those are only valid inside the session that loaded them. A per-state session would hand the next iteration a detached object.

Also kept `fetch_locations_from_db`'s conversion to `LocationResult` *inside* the scope. Reading attributes off a detached instance works while they happen to be loaded — but it's one lazy relationship away from `DetachedInstanceError`, and that latent fragility is the thing this ticket exists to remove.

## Twelve modules, five different shapes

Worth recording, because the ticket's original "pass `Depends(get_db)` from endpoints" turned out to fit exactly one of them:

| shape | modules |
|---|---|
| `Depends(get_db)` | `endpoints/location.py` — the only query that runs *during* a request |
| own scope, whole method | image storage, job classification agent |
| scope + private method taking `db` | role, seniority agent, linkedin, location agent |
| scope for the lookup, released before async work | seniority, job classification, location, company services |
| takes an **id**, loads in its own scope | coordinates — fire-and-forget, so it outlives any caller's scope |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD