### PR TITLE
ci(agents-api): add Railway config for the arq worker service

### DIFF
--- a/agents-api/railway.worker.toml
+++ b/agents-api/railway.worker.toml
@@ -1,0 +1,20 @@
+# Config for the arq worker service.
+#
+# A second Railway service runs from this same repo and root directory but
+# needs a different start command, so it points at this file via the service's
+# "Config file path" setting (/agents-api/railway.worker.toml). Railway's
+# config-as-code always overrides dashboard settings, so without a separate
+# file the worker would inherit railway.toml and start a second copy of the
+# API instead.
+
+[build]
+builder = "RAILPACK"
+
+[deploy]
+startCommand = ".venv/bin/arq app.tasks.worker.WorkerSettings"
+
+# No healthcheckPath: a worker serves no HTTP, so a healthcheck would never
+# pass and Railway would restart it forever.
+
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
The arq worker from #102 needs a Railway service to run in. This is its config.

## Why a separate file rather than a dashboard setting

The worker runs from the **same repo and root directory** as the Agents API, but needs a different start command. Railway's docs are explicit that *"configuration defined in code will always override values from the dashboard"* — so a worker service left pointing at `railway.toml` would inherit:

```
startCommand = ".venv/bin/uvicorn app.main:app --host 0.0.0.0 --port $PORT"
```

…and quietly run **a second copy of the API** instead of processing the queue. It would even pass its healthcheck, so it'd look fine while the queue silently filled up.

Pointing the service at this file via its **Config file path** setting is the documented way to give one service in a repo its own configuration.

## No healthcheck, deliberately

`railway.toml` has `healthcheckPath = "/health"`. A worker serves no HTTP, so that check could never pass and Railway would restart it forever.

## Verified locally

```
Starting worker for 7 functions: extract_linkedin_profile, update_linkedin_profiles,
update_companies, classify_alumni_roles, classify_alumni_seniority,
resolve_role_locations, resolve_alumni_role_locations
redis_version=7.4.10 ... Worker started
```

## Dashboard steps after merge

The CLI can create the service and set variables, but root directory and config path are dashboard settings:

1. New service → deploy from this repo, branch `main`
2. Settings → **Root Directory**: `agents-api`
3. Settings → **Config file path**: `/agents-api/railway.worker.toml`
4. Variables: same set as the Agents API service (`DATABASE_URL`, `REDIS_URL`, `OPENAI_API_KEY`, the enrichment keys)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD