### PR TITLE
fix(agents-api): import task_queue in the classification endpoint, gate ruff F rules

### DIFF
--- a/.github/workflows/agents-api-tests.yml
+++ b/.github/workflows/agents-api-tests.yml
@@ -60,8 +60,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
-      - name: Lint the test suite
+      - name: Lint
+        # The full ruleset cannot gate app/ yet - it still carries pre-existing
+        # E501s, tracked in CAR-163. The F rules can, and they are the ones that
+        # catch bugs rather than style: F821 undefined-name shipped a production
+        # 500 in #102 precisely because nothing gated it.
         run: |
+          uv run ruff check app/ --select F
           uv run ruff check tests/
           uv run ruff format --check tests/
 

--- a/agents-api/app/api/endpoints/job_classification.py
+++ b/agents-api/app/api/endpoints/job_classification.py
@@ -4,6 +4,7 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.schemas.job_classification import AlumniJobClassificationParams, EscoResult
+from app.tasks.queue import task_queue
 from app.utils.agents.esco_reference import search_esco_classifications
 
 router = APIRouter()

--- a/agents-api/app/services/seniority.py
+++ b/agents-api/app/services/seniority.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import math
 from datetime import datetime
 from typing import List
 
@@ -174,9 +175,7 @@ class SeniorityService:
         for i in range(0, len(ids), self.BATCH_SIZE):
             batch = ids[i : i + self.BATCH_SIZE]
             batch_no = i // self.BATCH_SIZE + 1
-            # logger.info(
-            #     f"Processing batch {batch_no} of {math.ceil(len(ids) / self.BATCH_SIZE)}"
-            # )
+            logger.info(f"Processing batch {batch_no} of {math.ceil(len(ids) / self.BATCH_SIZE)}")
 
             tasks = [asyncio.create_task(self.process_alumni_roles(aid)) for aid in batch]
             await asyncio.gather(*tasks)


### PR DESCRIPTION
`POST /api/job-classification/` returned **500 — `name 'task_queue' is not defined`**. The queue migration in #102 added the enqueue call to that endpoint but not its import.

## Ruff had already found it

```
app/api/endpoints/job_classification.py:28:15: F821 Undefined name `task_queue`
```

It was sitting in the 46-violation baseline for `app/`, indistinguishable from 44 line-length complaints — and nothing gates that check. **A real bug shipped inside a pile of style noise.**

Audited the other five enqueue call sites; only this one was affected.

## The fix worth having is the gate, not the import

The `F` ruleset — undefined names, unused imports, unused variables — was **one violation** away from passing. CI now runs:

```
uv run ruff check app/ --select F
```

The full ruleset still can't gate until the E501s are cleared (CAR-163), but the rules that catch *bugs* rather than *style* now do.

## That last violation, and what enabling the rules immediately caught

It was an unused `batch_no`, orphaned when a progress log got commented out. I restored the log rather than deleting the variable — the classification service logs the same thing, and seniority runs are long enough to want it.

Enabling the rules then immediately flagged that the commented-out line referenced `math`, whose import had been removed as unused. So the ruleset caught a second latent bug within seconds of being switched on, which is a fairer argument for it than anything I could write here.

```
69 passed, 2 xfailed
ruff --select F on app/: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QP2QQMWszyzbXnUA1YJFD