### PR TITLE
ci: only run agents-api tests when agents-api changes

### DIFF
--- a/.github/workflows/agents-api-tests.yml
+++ b/.github/workflows/agents-api-tests.yml
@@ -11,8 +11,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # pytest is a required status check, so the paths filter cannot live on the
+  # trigger: a workflow that never runs never reports, and branch protection
+  # waits for it forever. Gating the job instead keeps the check reported, and
+  # a skipped required job counts as satisfied.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.filter.outputs.agents }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            agents:
+              - 'agents-api/**'
+              - '.github/workflows/agents-api-tests.yml'
+              # The suite applies this schema to the test database, and the
+              # SQLAlchemy models mirror it, so a schema change can break these
+              # tests without touching agents-api.
+              - 'api/prisma/schema.prisma'
+
   test:
     name: pytest
+    needs: changes
+    if: needs.changes.outputs.agents == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
The suite runs on every pull request, including ones it does not cover. #105 deleted two files at the repository root and still spun up Postgres, installed Python and ran pytest.

## Why the filter is on the job, not the trigger

`pytest` is a required status check. A `paths` filter on `on: pull_request` means the workflow does not run at all for unrelated changes, so no `pytest` status is ever reported and branch protection waits for it forever: the pull request becomes unmergeable with *Expected — Waiting for status to be reported*. That trades a slow CI for a stuck one.

Gating the job instead keeps the workflow running and the check reported. GitHub treats a **skipped** required job as satisfied, so unrelated pull requests go green immediately.

## Paths watched

| Path | Why |
| --- | --- |
| `agents-api/**` | The code under test |
| `.github/workflows/agents-api-tests.yml` | So a change to CI tests itself |
| `api/prisma/schema.prisma` | The suite applies this schema to its test database, and the SQLAlchemy models mirror it, so a schema change can break these tests without touching `agents-api` |

## Verifying it

This pull request touches only the workflow, which is in the filter, so `pytest` should **run** here. The next pull request that touches neither `agents-api/` nor the schema should show `pytest` as skipped and still be mergeable.