### PR TITLE
feat(pipeline): staged execution with resume-at-stage (CAR-157)

### DIFF
--- a/agents-api/app/api/endpoints/job_classification.py
+++ b/agents-api/app/api/endpoints/job_classification.py
@@ -3,6 +3,9 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from app.db.session import session_scope
+from app.pipeline.runs import create_run, ensure_stages
+from app.pipeline.stages import PipelineKind, PipelineStageName
 from app.schemas.job_classification import AlumniJobClassificationParams, EscoResult
 from app.tasks.queue import task_queue
 from app.utils.agents.esco_reference import search_esco_classifications
@@ -26,7 +29,20 @@ async def classify_job(
     try:
         logger.info(f"Requesting alumni role classification for {params.alumni_ids}")
 
-        await task_queue.enqueue("classify_alumni_roles", alumni_ids=params.alumni_ids)
+        with session_scope() as db:
+            run = create_run(
+                db,
+                kind=PipelineKind.REFRESH_EXISTING,
+                params={"alumni_ids": params.alumni_ids},
+            )
+            db.flush()
+            ensure_stages(db, run)
+            run_id = run.id
+
+        await task_queue.enqueue(
+            "run_stage", run_id=run_id, stage=PipelineStageName.CLASSIFY_ROLES.value
+        )
+        return {"run_id": run_id}
 
     except Exception as e:
         logger.error(f"Error requesting alumni role classification: {str(e)}")

--- a/agents-api/app/api/endpoints/job_classification.py
+++ b/agents-api/app/api/endpoints/job_classification.py
@@ -38,6 +38,9 @@ async def classify_job(
             db.flush()
             ensure_stages(db, run)
             run_id = run.id
+            # session_scope does not commit. Without this the run is gone by the
+            # time the worker looks for it, and run_stage finds nothing.
+            db.commit()
 
         await task_queue.enqueue(
             "run_stage", run_id=run_id, stage=PipelineStageName.CLASSIFY_ROLES.value

--- a/agents-api/app/db/models.py
+++ b/agents-api/app/db/models.py
@@ -17,6 +17,21 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 from app.db.session import Base
+
+# The pipeline enums are defined in app.pipeline.stages rather than here: the
+# stage machine has to be importable without a database, and importing anything
+# under app.db constructs an engine as a side effect (app/db/__init__.py ->
+# session.py). Re-exported below so `from app.db.models import PipelineStageName`
+# keeps working alongside the other model enums.
+from app.pipeline.stages import (
+    PipelineEntityType,
+    PipelineKind,
+    PipelineRunStatus,
+    PipelineStageName,
+    PipelineStageStatus,
+    PipelineTaskStatus,
+    PipelineTrigger,
+)
 from app.utils.consts import DEFAULT_INDUSTRY_ID
 
 
@@ -298,58 +313,6 @@ class EscoClassification(Base):
     embedding = Column(Vector(3072), nullable=True)
 
     job_classification = relationship("JobClassification", back_populates="esco_classification")
-
-
-class PipelineKind(str, enum.Enum):
-    REFRESH_EXISTING = "REFRESH_EXISTING"
-    INGEST_COHORT = "INGEST_COHORT"
-
-
-class PipelineTrigger(str, enum.Enum):
-    ADMIN_UI = "ADMIN_UI"
-    API = "API"
-    SCHEDULE = "SCHEDULE"
-
-
-class PipelineRunStatus(str, enum.Enum):
-    PLANNING = "PLANNING"
-    PLANNED = "PLANNED"
-    RUNNING = "RUNNING"
-    COMPLETED = "COMPLETED"
-    FAILED = "FAILED"
-    CANCELLED = "CANCELLED"
-
-
-class PipelineStageName(str, enum.Enum):
-    PLAN = "PLAN"
-    LINKEDIN = "LINKEDIN"
-    COMPANY = "COMPANY"
-    CLASSIFY_ROLES = "CLASSIFY_ROLES"
-    SENIORITY = "SENIORITY"
-    LOCATION = "LOCATION"
-
-
-class PipelineStageStatus(str, enum.Enum):
-    PENDING = "PENDING"
-    RUNNING = "RUNNING"
-    COMPLETED = "COMPLETED"
-    FAILED = "FAILED"
-    SKIPPED = "SKIPPED"
-
-
-class PipelineTaskStatus(str, enum.Enum):
-    QUEUED = "QUEUED"
-    RUNNING = "RUNNING"
-    SUCCEEDED = "SUCCEEDED"
-    FAILED = "FAILED"
-    SKIPPED = "SKIPPED"
-
-
-class PipelineEntityType(str, enum.Enum):
-    ALUMNI = "ALUMNI"
-    ROLE = "ROLE"
-    COMPANY = "COMPANY"
-    LOCATION = "LOCATION"
 
 
 # The Postgres enum types are created by Prisma and named in SCREAMING_SNAKE.

--- a/agents-api/app/pipeline/__init__.py
+++ b/agents-api/app/pipeline/__init__.py
@@ -1,0 +1,6 @@
+"""The staged pipeline: stage ordering, transition rules and the executor.
+
+`stages`, `sequence` and `state` are pure - no database, no Redis, no arq - so
+the rules that decide what runs next can be tested without infrastructure.
+`executor` is the only module that bridges them to the services and the tables.
+"""

--- a/agents-api/app/pipeline/control.py
+++ b/agents-api/app/pipeline/control.py
@@ -1,0 +1,58 @@
+"""The cancellation flag.
+
+Kept in Redis rather than read from `pipeline_run.status`: the executor checks
+it once per chunk, and a Postgres read on that path buys nothing over a key
+lookup. The run's own status is still updated when the executor observes the
+flag, so the tables remain the durable record.
+"""
+
+import logging
+from typing import Awaitable, Callable, Optional
+
+from redis import Redis
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Long enough to outlive any run (the worker's job_timeout is six hours), short
+# enough that the keys do not accumulate. Run ids are never reused, so nothing
+# would otherwise clean them up.
+CANCEL_KEY_TTL = 60 * 60 * 24
+
+
+def cancel_key(run_id: str) -> str:
+    return f"pipeline:cancel:{run_id}"
+
+
+def _client(client: Optional[Redis]) -> Redis:
+    return client if client is not None else Redis.from_url(settings.REDIS_URL)
+
+
+def request_cancel(run_id: str, client: Optional[Redis] = None) -> None:
+    _client(client).setex(cancel_key(run_id), CANCEL_KEY_TTL, "1")
+    logger.info("Cancellation requested for run %s", run_id)
+
+
+def is_cancelled(run_id: str, client: Optional[Redis] = None) -> bool:
+    return bool(_client(client).exists(cancel_key(run_id)))
+
+
+def clear_cancel(run_id: str, client: Optional[Redis] = None) -> None:
+    _client(client).delete(cancel_key(run_id))
+
+
+def cancel_checker(
+    run_id: str, client: Optional[Redis] = None
+) -> Callable[[], Awaitable[bool]]:
+    """An `is_cancelled` callable in the shape `execute_stage` expects.
+
+    Reads on every call rather than closing over a value, so a cancel arriving
+    mid-stage is seen at the next chunk boundary.
+    """
+    resolved = _client(client)
+
+    async def check() -> bool:
+        return is_cancelled(run_id, resolved)
+
+    return check

--- a/agents-api/app/pipeline/executor.py
+++ b/agents-api/app/pipeline/executor.py
@@ -1,0 +1,248 @@
+"""The shell around the stage machine: rows in, services driven, status out.
+
+The only module in `app.pipeline` that knows about the database. Everything it
+decides it delegates to `state`, which is pure - so the rules stay testable
+without infrastructure and this file stays testable without mocking the rules.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from app.db.models import PipelineRun, PipelineStage, PipelineTask
+from app.pipeline.keys import idempotency_key
+from app.pipeline.stages import (
+    PipelineEntityType,
+    PipelineRunStatus,
+    PipelineStageStatus,
+    PipelineTaskStatus,
+)
+from app.pipeline.state import StageOutcome, TaskCounts, should_abort, stage_outcome
+
+logger = logging.getLogger(__name__)
+
+# A resume re-runs these; a stage never revisits the rest.
+RESUMABLE_STATUSES = (
+    PipelineTaskStatus.QUEUED,
+    PipelineTaskStatus.RUNNING,
+    PipelineTaskStatus.FAILED,
+)
+
+# Matches the BATCH_SIZE the services already fan out at, so converting a stage
+# does not change how hard it hits the providers.
+DEFAULT_CHUNK_SIZE = 50
+
+DEFAULT_FAILURE_THRESHOLD = 0.2
+
+
+@dataclass(frozen=True)
+class StageSpec:
+    """What a stage needs beyond the machinery: its entities and its work.
+
+    Per-stage differences live here rather than in branches inside the executor,
+    so converting the remaining five stages is one entry each.
+    """
+
+    entity_type: PipelineEntityType
+    resolve: Callable[[Session, PipelineRun], Sequence[str]]
+    handle: Callable[[str], Awaitable[Optional[Dict[str, Any]]]]
+    chunk_size: int = DEFAULT_CHUNK_SIZE
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def failure_threshold(run: PipelineRun) -> float:
+    params = run.params or {}
+    return float(params.get("failure_threshold", DEFAULT_FAILURE_THRESHOLD))
+
+
+def materialize_tasks(
+    session: Session,
+    run: PipelineRun,
+    stage: PipelineStage,
+    entity_ids: Sequence[str],
+    entity_type: PipelineEntityType,
+) -> int:
+    """Create the stage's task rows, returning how many were new.
+
+    ON CONFLICT DO NOTHING rather than a read-then-insert: the unique constraint
+    is the arbiter, so a resume racing the original worker cannot produce two
+    rows for the same entity.
+    """
+    if not entity_ids:
+        return 0
+
+    rows = [
+        {
+            "stage_id": stage.id,
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "status": PipelineTaskStatus.QUEUED,
+            "idempotency_key": idempotency_key(run.id, stage.stage, entity_id),
+        }
+        for entity_id in entity_ids
+    ]
+
+    statement = (
+        insert(PipelineTask)
+        .values(rows)
+        .on_conflict_do_nothing(index_elements=[PipelineTask.idempotency_key])
+    )
+    return session.execute(statement).rowcount
+
+
+def count_tasks(session: Session, stage_id: str) -> TaskCounts:
+    """Tally the stage's rows into the shape the transition rules expect."""
+    grouped = dict(
+        session.query(PipelineTask.status, func.count())
+        .filter(PipelineTask.stage_id == stage_id)
+        .group_by(PipelineTask.status)
+        .all()
+    )
+    return TaskCounts(
+        total=sum(grouped.values()),
+        succeeded=grouped.get(PipelineTaskStatus.SUCCEEDED, 0),
+        failed=grouped.get(PipelineTaskStatus.FAILED, 0),
+        skipped=grouped.get(PipelineTaskStatus.SKIPPED, 0),
+    )
+
+
+def pending_entity_ids(session: Session, stage_id: str) -> List[str]:
+    """The entities a run of this stage should attempt.
+
+    SUCCEEDED is excluded because redoing it is the cost resume exists to avoid;
+    SKIPPED because that decision was already taken about the entity.
+    """
+    rows = (
+        session.query(PipelineTask.entity_id)
+        .filter(
+            PipelineTask.stage_id == stage_id,
+            PipelineTask.status.in_(RESUMABLE_STATUSES),
+        )
+        .order_by(PipelineTask.entity_id)
+        .all()
+    )
+    return [row[0] for row in rows]
+
+
+def _chunks(items: List[str], size: int):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def _flush_counts(session: Session, stage: PipelineStage, counts: TaskCounts) -> None:
+    stage.total_count = counts.total
+    stage.succeeded_count = counts.succeeded
+    stage.failed_count = counts.failed
+    stage.skipped_count = counts.skipped
+    session.flush()
+
+
+def _finish_task(
+    session: Session,
+    stage_id: str,
+    entity_id: str,
+    status: PipelineTaskStatus,
+    result: Optional[Dict[str, Any]],
+    error: Optional[str],
+) -> None:
+    task = (
+        session.query(PipelineTask)
+        .filter(PipelineTask.stage_id == stage_id, PipelineTask.entity_id == entity_id)
+        .one()
+    )
+    task.status = status
+    task.result = result
+    task.error = error
+    task.attempts = (task.attempts or 0) + 1
+    task.finished_at = _now()
+
+
+async def execute_stage(
+    session: Session,
+    run: PipelineRun,
+    stage: PipelineStage,
+    spec: StageSpec,
+    is_cancelled: Optional[Callable[[], Awaitable[bool]]] = None,
+) -> StageOutcome:
+    """Drive one stage to a terminal outcome.
+
+    Re-materializes before running so that a resume and a first run take the
+    same path - the unique constraint absorbs the rows that already exist.
+    """
+    threshold = failure_threshold(run)
+
+    materialize_tasks(session, run, stage, spec.resolve(session, run), spec.entity_type)
+    session.flush()
+
+    stage.status = PipelineStageStatus.RUNNING
+    stage.started_at = stage.started_at or _now()
+    _flush_counts(session, stage, count_tasks(session, stage.id))
+
+    for chunk in _chunks(pending_entity_ids(session, stage.id), spec.chunk_size):
+        if is_cancelled is not None and await is_cancelled():
+            run.status = PipelineRunStatus.CANCELLED
+            run.finished_at = _now()
+            session.flush()
+            logger.info("Run %s cancelled during stage %s", run.id, stage.stage)
+            return StageOutcome.CANCELLED
+
+        outcomes = await asyncio.gather(
+            *(spec.handle(entity_id) for entity_id in chunk), return_exceptions=True
+        )
+
+        for entity_id, outcome in zip(chunk, outcomes):
+            if isinstance(outcome, BaseException):
+                logger.warning(
+                    "Stage %s failed on %s: %s", stage.stage, entity_id, outcome
+                )
+                _finish_task(
+                    session,
+                    stage.id,
+                    entity_id,
+                    PipelineTaskStatus.FAILED,
+                    None,
+                    f"{type(outcome).__name__}: {outcome}",
+                )
+            else:
+                _finish_task(
+                    session, stage.id, entity_id, PipelineTaskStatus.SUCCEEDED, outcome, None
+                )
+
+        counts = count_tasks(session, stage.id)
+        _flush_counts(session, stage, counts)
+
+        # Evaluated per chunk rather than at the end: the point is to stop
+        # paying for a provider that is down, not to report it afterwards.
+        if should_abort(counts, threshold):
+            stage.status = PipelineStageStatus.FAILED
+            stage.finished_at = _now()
+            stage.error = (
+                f"Aborted: {counts.failed}/{counts.terminal} tasks failed, "
+                f"over the {threshold:.0%} failure threshold"
+            )
+            run.status = PipelineRunStatus.FAILED
+            run.error = f"Stage {stage.stage.value} exceeded its failure threshold"
+            run.finished_at = _now()
+            session.flush()
+            return StageOutcome.ABORT_THRESHOLD
+
+    counts = count_tasks(session, stage.id)
+    _flush_counts(session, stage, counts)
+    outcome = stage_outcome(counts, threshold)
+
+    if outcome is StageOutcome.COMPLETE:
+        stage.status = PipelineStageStatus.COMPLETED
+        stage.finished_at = _now()
+        session.flush()
+
+    return outcome

--- a/agents-api/app/pipeline/executor.py
+++ b/agents-api/app/pipeline/executor.py
@@ -147,6 +147,23 @@ def _flush_counts(session: Session, stage: PipelineStage, counts: TaskCounts) ->
     session.flush()
 
 
+def _mark_running(session: Session, stage_id: str, entity_ids: List[str]) -> None:
+    """Claim a chunk before working it.
+
+    One statement for the whole chunk. Without it a killed worker leaves its
+    in-flight rows in QUEUED, where the recovery sweep cannot tell them apart
+    from work that was never started.
+    """
+    session.query(PipelineTask).filter(
+        PipelineTask.stage_id == stage_id,
+        PipelineTask.entity_id.in_(entity_ids),
+    ).update(
+        {PipelineTask.status: PipelineTaskStatus.RUNNING, PipelineTask.started_at: _now()},
+        synchronize_session=False,
+    )
+    session.flush()
+
+
 def _finish_task(
     session: Session,
     stage_id: str,
@@ -195,6 +212,8 @@ async def execute_stage(
             session.flush()
             logger.info("Run %s cancelled during stage %s", run.id, stage.stage)
             return StageOutcome.CANCELLED
+
+        _mark_running(session, stage.id, chunk)
 
         outcomes = await asyncio.gather(
             *(spec.handle(entity_id) for entity_id in chunk), return_exceptions=True

--- a/agents-api/app/pipeline/executor.py
+++ b/agents-api/app/pipeline/executor.py
@@ -161,7 +161,10 @@ def _mark_running(session: Session, stage_id: str, entity_ids: List[str]) -> Non
         {PipelineTask.status: PipelineTaskStatus.RUNNING, PipelineTask.started_at: _now()},
         synchronize_session=False,
     )
-    session.flush()
+    # Committed, not just flushed: an uncommitted claim is rolled back when a
+    # killed worker's session dies, leaving the rows in QUEUED and the recovery
+    # sweep with nothing to find.
+    session.commit()
 
 
 def _finish_task(
@@ -209,7 +212,7 @@ async def execute_stage(
         if is_cancelled is not None and await is_cancelled():
             run.status = PipelineRunStatus.CANCELLED
             run.finished_at = _now()
-            session.flush()
+            session.commit()
             logger.info("Run %s cancelled during stage %s", run.id, stage.stage)
             return StageOutcome.CANCELLED
 
@@ -240,6 +243,11 @@ async def execute_stage(
         counts = count_tasks(session, stage.id)
         _flush_counts(session, stage, counts)
 
+        # session_scope does not commit (app/db/session.py), so without this the
+        # worker's whole session is discarded on close and a kill resumes from
+        # nothing. Committing per chunk is what makes progress survive.
+        session.commit()
+
         # Evaluated per chunk rather than at the end: the point is to stop
         # paying for a provider that is down, not to report it afterwards.
         if should_abort(counts, threshold):
@@ -252,7 +260,7 @@ async def execute_stage(
             run.status = PipelineRunStatus.FAILED
             run.error = f"Stage {stage.stage.value} exceeded its failure threshold"
             run.finished_at = _now()
-            session.flush()
+            session.commit()
             return StageOutcome.ABORT_THRESHOLD
 
     counts = count_tasks(session, stage.id)
@@ -262,6 +270,6 @@ async def execute_stage(
     if outcome is StageOutcome.COMPLETE:
         stage.status = PipelineStageStatus.COMPLETED
         stage.finished_at = _now()
-        session.flush()
+        session.commit()
 
     return outcome

--- a/agents-api/app/pipeline/keys.py
+++ b/agents-api/app/pipeline/keys.py
@@ -1,0 +1,26 @@
+"""Derivation of PipelineTask.idempotency_key.
+
+CAR-155 put a unique constraint on this column, which is what makes dedup a
+database guarantee rather than a race between workers. That only holds if the
+value is derived the same way every time, so it lives in one function rather
+than at each call site.
+"""
+
+import hashlib
+
+from app.pipeline.stages import PipelineStageName
+
+
+def idempotency_key(run_id: str, stage: PipelineStageName, entity_id: str) -> str:
+    """Identify one entity's work in one stage of one run.
+
+    Length-prefixed before hashing: joining on a separator alone lets an entity
+    id that contains the separator collide with a different triple, which would
+    silently drop real work at the unique constraint.
+
+    Scoped to the run because two runs over the same alumni are legitimate - a
+    refresh next month is not this month's work.
+    """
+    parts = (run_id, stage.value, entity_id)
+    payload = "".join(f"{len(part)}:{part}" for part in parts)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/agents-api/app/pipeline/recovery.py
+++ b/agents-api/app/pipeline/recovery.py
@@ -1,0 +1,42 @@
+"""Recovering work a dead worker left mid-flight.
+
+A killed worker leaves its in-flight tasks in RUNNING with nothing to move them.
+They are indistinguishable from live work except by age, which is why the sweep
+is a timeout rather than a status check.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.db.models import PipelineTask
+from app.pipeline.stages import PipelineTaskStatus
+
+logger = logging.getLogger(__name__)
+
+# Above the worker's job_timeout of six hours, so a stage that is merely slow is
+# never mistaken for a dead one.
+DEFAULT_STUCK_TIMEOUT = timedelta(hours=8)
+
+
+def recover_stuck_tasks(session: Session, timeout: timedelta = DEFAULT_STUCK_TIMEOUT) -> int:
+    """Return tasks abandoned in RUNNING to QUEUED, returning how many."""
+    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timeout
+
+    reset = (
+        session.query(PipelineTask)
+        .filter(
+            PipelineTask.status == PipelineTaskStatus.RUNNING,
+            PipelineTask.started_at < cutoff,
+        )
+        # "fetch" rather than False: the startup sweep runs on a fresh session
+        # where it would not matter, but a caller holding those rows would
+        # otherwise keep seeing RUNNING after the reset. One extra SELECT on a
+        # once-per-startup sweep is not worth that trap.
+        .update({PipelineTask.status: PipelineTaskStatus.QUEUED}, synchronize_session="fetch")
+    )
+
+    if reset:
+        logger.warning("Reset %s task(s) abandoned in RUNNING past %s", reset, timeout)
+    return reset

--- a/agents-api/app/pipeline/registry.py
+++ b/agents-api/app/pipeline/registry.py
@@ -1,0 +1,53 @@
+"""Which service each stage drives, and over which entities.
+
+Only CLASSIFY_ROLES is converted (CAR-157). The other stages keep their existing
+coarse tasks until they are converted one at a time against a proven executor,
+so an unconverted stage is absent here rather than half-wired.
+
+Services are imported inside the resolvers and handlers for the same reason
+app/tasks/pipeline.py does it: importing them at module scope drags langchain
+and torch into the web process, which only ever enqueues.
+"""
+
+from typing import Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.db.models import PipelineRun
+from app.pipeline.executor import StageSpec
+from app.pipeline.stages import PipelineEntityType, PipelineStageName
+
+
+def _resolve_alumni(session: Session, run: PipelineRun) -> List[str]:
+    """The alumni a run covers, from its params - all of them if unspecified.
+
+    Mirrors the lookup request_alumni_classification does, but reads the scope
+    from the run rather than from a function argument, so a resume recovers it
+    from the database instead of needing it passed in again.
+    """
+    from app.utils.alumni_db import find_all, find_by_ids
+
+    params = run.params or {}
+    alumni_ids: Optional[str] = params.get("alumni_ids")
+
+    alumni = find_by_ids(alumni_ids.split(","), session) if alumni_ids else find_all(session)
+    return sorted({record.id for record in alumni})
+
+
+async def _classify_roles(alumni_id: str) -> None:
+    from app.services.job_classification import job_classification_service
+
+    await job_classification_service.classify_roles_for_alumni(alumni_id)
+
+
+STAGES: Dict[PipelineStageName, StageSpec] = {
+    PipelineStageName.CLASSIFY_ROLES: StageSpec(
+        entity_type=PipelineEntityType.ALUMNI,
+        resolve=_resolve_alumni,
+        handle=_classify_roles,
+    ),
+}
+
+
+def spec_for(stage: PipelineStageName) -> Optional[StageSpec]:
+    return STAGES.get(stage)

--- a/agents-api/app/pipeline/runs.py
+++ b/agents-api/app/pipeline/runs.py
@@ -1,0 +1,153 @@
+"""Run lifecycle: create, resume, cancel.
+
+CAR-159 puts HTTP endpoints in front of `resume_run` and `cancel_run`; they are
+functions here so that the two tickets do not both own the same behaviour.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from redis import Redis
+from sqlalchemy.orm import Session
+
+from app.db.models import PipelineRun, PipelineStage, PipelineTask
+from app.pipeline.control import clear_cancel, request_cancel
+from app.pipeline.sequence import STAGE_SEQUENCE, sequence_of
+from app.pipeline.stages import (
+    PipelineKind,
+    PipelineRunStatus,
+    PipelineStageName,
+    PipelineStageStatus,
+    PipelineTaskStatus,
+    PipelineTrigger,
+)
+from app.pipeline.state import resume_targets
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def create_run(
+    session: Session,
+    kind: PipelineKind,
+    params: Optional[Dict[str, Any]] = None,
+    trigger_source: PipelineTrigger = PipelineTrigger.API,
+    triggered_by: Optional[str] = None,
+) -> PipelineRun:
+    run = PipelineRun(
+        kind=kind,
+        status=PipelineRunStatus.PLANNING,
+        params=params,
+        trigger_source=trigger_source,
+        triggered_by=triggered_by,
+    )
+    session.add(run)
+    return run
+
+
+def ensure_stages(session: Session, run: PipelineRun) -> Dict[PipelineStageName, PipelineStage]:
+    """Create the run's stage rows, one per stage in the sequence.
+
+    Rows for every stage exist from the start even though their tasks do not:
+    the status endpoints in CAR-159 need something to report progress against
+    before a stage has been reached.
+    """
+    existing = {
+        row.stage: row
+        for row in session.query(PipelineStage).filter(PipelineStage.run_id == run.id).all()
+    }
+
+    for stage_name in STAGE_SEQUENCE:
+        if stage_name in existing:
+            continue
+        row = PipelineStage(
+            run_id=run.id,
+            stage=stage_name,
+            sequence=sequence_of(stage_name),
+            status=PipelineStageStatus.PENDING,
+        )
+        session.add(row)
+        existing[stage_name] = row
+
+    session.flush()
+    return existing
+
+
+def resume_run(
+    session: Session,
+    run: PipelineRun,
+    from_stage: PipelineStageName,
+    redis_client: Optional[Redis] = None,
+) -> PipelineStageName:
+    """Reopen `from_stage` onwards and report which stage to enqueue.
+
+    Task rows are deliberately left as they are. The executor already skips
+    SUCCEEDED and SKIPPED and retries the rest, so resetting them here would
+    only discard the record of what the previous attempt achieved.
+    """
+    targets = resume_targets(from_stage)
+    stages = ensure_stages(session, run)
+
+    for stage_name in targets:
+        stage = stages[stage_name]
+        stage.status = PipelineStageStatus.PENDING
+        stage.error = None
+        stage.finished_at = None
+
+    run.status = PipelineRunStatus.RUNNING
+    run.error = None
+    run.finished_at = None
+    run.started_at = run.started_at or _now()
+
+    clear_cancel(run.id, redis_client)
+    session.flush()
+
+    logger.info("Run %s resumed from %s", run.id, from_stage.value)
+    return from_stage
+
+
+def cancel_run(
+    session: Session, run: PipelineRun, redis_client: Optional[Redis] = None
+) -> None:
+    """Ask the executor to stop at its next chunk boundary.
+
+    The flag is set before the status so that a worker reading it mid-stage
+    cannot miss the cancel and then find the run already marked cancelled.
+    """
+    request_cancel(run.id, redis_client)
+
+    run.status = PipelineRunStatus.CANCELLED
+    run.finished_at = _now()
+    session.flush()
+
+
+def stage_row(
+    session: Session, run: PipelineRun, stage_name: PipelineStageName
+) -> PipelineStage:
+    return (
+        session.query(PipelineStage)
+        .filter(PipelineStage.run_id == run.id, PipelineStage.stage == stage_name)
+        .one()
+    )
+
+
+def has_unfinished_tasks(session: Session, stage: PipelineStage) -> bool:
+    return (
+        session.query(PipelineTask)
+        .filter(
+            PipelineTask.stage_id == stage.id,
+            PipelineTask.status.in_(
+                (
+                    PipelineTaskStatus.QUEUED,
+                    PipelineTaskStatus.RUNNING,
+                    PipelineTaskStatus.FAILED,
+                )
+            ),
+        )
+        .count()
+        > 0
+    )

--- a/agents-api/app/pipeline/runs.py
+++ b/agents-api/app/pipeline/runs.py
@@ -104,7 +104,10 @@ def resume_run(
     run.started_at = run.started_at or _now()
 
     clear_cancel(run.id, redis_client)
-    session.flush()
+    # Committed rather than flushed: session_scope does not commit, and a
+    # resume that is rolled back leaves the run looking failed while its stage
+    # job is already queued.
+    session.commit()
 
     logger.info("Run %s resumed from %s", run.id, from_stage.value)
     return from_stage
@@ -122,7 +125,7 @@ def cancel_run(
 
     run.status = PipelineRunStatus.CANCELLED
     run.finished_at = _now()
-    session.flush()
+    session.commit()
 
 
 def stage_row(

--- a/agents-api/app/pipeline/sequence.py
+++ b/agents-api/app/pipeline/sequence.py
@@ -1,0 +1,27 @@
+"""The stage order, defined once."""
+
+from typing import Optional
+
+from app.pipeline.stages import PipelineStageName
+
+# PLAN keeps its slot while CAR-158 is outstanding, so filling it in later is not
+# a renumber.
+STAGE_SEQUENCE: tuple[PipelineStageName, ...] = (
+    PipelineStageName.PLAN,
+    PipelineStageName.LINKEDIN,
+    PipelineStageName.COMPANY,
+    PipelineStageName.CLASSIFY_ROLES,
+    PipelineStageName.SENIORITY,
+    PipelineStageName.LOCATION,
+)
+
+
+def sequence_of(stage: PipelineStageName) -> int:
+    return STAGE_SEQUENCE.index(stage)
+
+
+def next_stage(current: PipelineStageName) -> Optional[PipelineStageName]:
+    position = sequence_of(current)
+    if position + 1 >= len(STAGE_SEQUENCE):
+        return None
+    return STAGE_SEQUENCE[position + 1]

--- a/agents-api/app/pipeline/stages.py
+++ b/agents-api/app/pipeline/stages.py
@@ -1,0 +1,71 @@
+"""Pipeline enum values, mirrored from the Prisma schema.
+
+These live here rather than in `app.db.models` because the stage machine has to
+be importable without a database: `app.db.__init__` imports `session`, which
+calls `create_engine` at module scope, so importing an enum from there would
+construct an engine as a side effect. `app.db.models` imports these for its
+Column definitions, so the values still have one definition.
+"""
+
+import enum
+
+
+class PipelineKind(str, enum.Enum):
+    REFRESH_EXISTING = "REFRESH_EXISTING"
+    INGEST_COHORT = "INGEST_COHORT"
+
+
+class PipelineTrigger(str, enum.Enum):
+    ADMIN_UI = "ADMIN_UI"
+    API = "API"
+    SCHEDULE = "SCHEDULE"
+
+
+class PipelineRunStatus(str, enum.Enum):
+    PLANNING = "PLANNING"
+    PLANNED = "PLANNED"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+
+
+class PipelineStageName(str, enum.Enum):
+    PLAN = "PLAN"
+    LINKEDIN = "LINKEDIN"
+    COMPANY = "COMPANY"
+    CLASSIFY_ROLES = "CLASSIFY_ROLES"
+    SENIORITY = "SENIORITY"
+    LOCATION = "LOCATION"
+
+
+class PipelineStageStatus(str, enum.Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    SKIPPED = "SKIPPED"
+
+
+class PipelineTaskStatus(str, enum.Enum):
+    QUEUED = "QUEUED"
+    RUNNING = "RUNNING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    SKIPPED = "SKIPPED"
+
+
+class PipelineEntityType(str, enum.Enum):
+    ALUMNI = "ALUMNI"
+    ROLE = "ROLE"
+    COMPANY = "COMPANY"
+    LOCATION = "LOCATION"
+
+
+TERMINAL_TASK_STATUSES = frozenset(
+    {
+        PipelineTaskStatus.SUCCEEDED,
+        PipelineTaskStatus.FAILED,
+        PipelineTaskStatus.SKIPPED,
+    }
+)

--- a/agents-api/app/pipeline/state.py
+++ b/agents-api/app/pipeline/state.py
@@ -1,0 +1,78 @@
+"""Transition rules for the staged pipeline.
+
+Pure functions over plain values: nothing here opens a session, touches Redis or
+knows arq exists. The executor builds `TaskCounts` from rows and asks these
+functions what to do next, which is what lets the rules that decide whether a run
+continues be tested with no infrastructure.
+"""
+
+import enum
+from dataclasses import dataclass
+from typing import Tuple
+
+from app.pipeline.sequence import STAGE_SEQUENCE, sequence_of
+from app.pipeline.stages import PipelineStageName
+
+# Below this many finished tasks the failure rate is noise: the first task
+# failing reads as 100% and would abort a 3000-task run on one transient error.
+MIN_SAMPLE_FOR_THRESHOLD = 20
+
+
+class StageOutcome(str, enum.Enum):
+    RUNNING = "RUNNING"
+    COMPLETE = "COMPLETE"
+    ABORT_THRESHOLD = "ABORT_THRESHOLD"
+
+
+@dataclass(frozen=True)
+class TaskCounts:
+    total: int
+    succeeded: int
+    failed: int
+    skipped: int
+
+    @property
+    def terminal(self) -> int:
+        return self.succeeded + self.failed + self.skipped
+
+    @property
+    def pending(self) -> int:
+        return self.total - self.terminal
+
+    @property
+    def failure_rate(self) -> float:
+        """Failures as a share of what has finished, not of the whole stage.
+
+        Against `total`, a stage whose first hundred tasks all failed out of a
+        thousand reports 10% and keeps spending money on an endpoint that is
+        down. Against `terminal` the threshold is an early stop rather than a
+        post-mortem.
+        """
+        if self.terminal == 0:
+            return 0.0
+        return self.failed / self.terminal
+
+
+def should_abort(counts: TaskCounts, threshold: float) -> bool:
+    """Exclusive: a threshold of 0.2 permits exactly 20% and trips above it."""
+    if counts.terminal < MIN_SAMPLE_FOR_THRESHOLD:
+        return False
+    return counts.failure_rate > threshold
+
+
+def stage_outcome(counts: TaskCounts, threshold: float) -> StageOutcome:
+    """Aborting outranks completing.
+
+    A stage that reached the end with 80% failures must not hand its output to
+    the next stage merely because it has nothing left to run.
+    """
+    if should_abort(counts, threshold):
+        return StageOutcome.ABORT_THRESHOLD
+    if counts.pending <= 0:
+        # Empty stages land here too: nothing to wait for is done, not stuck.
+        return StageOutcome.COMPLETE
+    return StageOutcome.RUNNING
+
+
+def resume_targets(from_stage: PipelineStageName) -> Tuple[PipelineStageName, ...]:
+    return STAGE_SEQUENCE[sequence_of(from_stage) :]

--- a/agents-api/app/pipeline/state.py
+++ b/agents-api/app/pipeline/state.py
@@ -22,6 +22,9 @@ class StageOutcome(str, enum.Enum):
     RUNNING = "RUNNING"
     COMPLETE = "COMPLETE"
     ABORT_THRESHOLD = "ABORT_THRESHOLD"
+    # Not derivable from counts - the executor observes it and reports it here
+    # so callers have one outcome type to branch on.
+    CANCELLED = "CANCELLED"
 
 
 @dataclass(frozen=True)

--- a/agents-api/app/services/job_classification.py
+++ b/agents-api/app/services/job_classification.py
@@ -40,6 +40,10 @@ class JobClassificationService:
 
         except Exception as e:
             logger.error(f"Error classifying roles for alumni {alumni_id}: {str(e)}")
+            # Re-raised so the pipeline executor can mark the task FAILED.
+            # Swallowing here made every task look successful, which disabled
+            # the failure threshold and its abort path along with it.
+            raise
 
     async def request_alumni_classification(self, params: AlumniJobClassificationParams):
         """
@@ -63,7 +67,10 @@ class JobClassificationService:
             logger.info(f"Processing batch {batch_no} of {math.ceil(len(ids) / self.BATCH_SIZE)}")
 
             tasks = [asyncio.create_task(self.classify_roles_for_alumni(aid)) for aid in batch]
-            await asyncio.gather(*tasks)
+            # return_exceptions keeps this path behaving as it did before
+            # classify_roles_for_alumni started re-raising: one alumni failing
+            # must not abandon the rest of the batch.
+            await asyncio.gather(*tasks, return_exceptions=True)
 
             if i + self.BATCH_SIZE < len(alumni):
                 await asyncio.sleep(0.1)

--- a/agents-api/app/tasks/pipeline.py
+++ b/agents-api/app/tasks/pipeline.py
@@ -102,6 +102,7 @@ async def run_stage(ctx, run_id: str, stage: str) -> str:
             # An unconverted stage is skipped rather than treated as failed, so
             # the chain still reaches the stages that are converted.
             row.status = PipelineStageStatus.SKIPPED
+            db.commit()
             outcome = StageOutcome.COMPLETE
         else:
             run.status = PipelineRunStatus.RUNNING
@@ -115,8 +116,11 @@ async def run_stage(ctx, run_id: str, stage: str) -> str:
         if following is None:
             run.status = PipelineRunStatus.COMPLETED
             run.finished_at = datetime.now(timezone.utc).replace(tzinfo=None)
+            db.commit()
             logger.info("Run %s completed", run_id)
             return outcome.value
+
+        db.commit()
 
     # Enqueued outside the session: the next stage is minutes of work and has no
     # business inheriting this one's connection.

--- a/agents-api/app/tasks/pipeline.py
+++ b/agents-api/app/tasks/pipeline.py
@@ -10,10 +10,10 @@ is that a restart no longer loses the work.
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from app.schemas.company import CompanyUpdateParams
-from app.schemas.job_classification import AlumniJobClassificationParams
 from app.schemas.location import ResolveRoleLocationParams
 from app.schemas.seniority import AlumniSeniorityParams
 
@@ -44,12 +44,9 @@ async def update_companies(ctx, company_ids: Optional[str] = None) -> None:
     await company_service.request_company_update(CompanyUpdateParams(company_ids=company_ids))
 
 
-async def classify_alumni_roles(ctx, alumni_ids: Optional[str] = None) -> None:
-    from app.services.job_classification import job_classification_service
-
-    await job_classification_service.request_alumni_classification(
-        params=AlumniJobClassificationParams(alumni_ids=alumni_ids)
-    )
+# classify_alumni_roles is gone: the CLASSIFY_ROLES stage now owns that path, so
+# leaving the task registered would be one more entry point writing no run
+# record. The service method it called is still used by the LinkedIn service.
 
 
 async def classify_alumni_seniority(ctx, alumni_ids: Optional[str] = None) -> None:
@@ -70,13 +67,70 @@ async def resolve_alumni_role_locations(ctx, alumni_id: str) -> None:
     await location_service.resolve_role_location_for_alumni(alumni_id)
 
 
+async def run_stage(ctx, run_id: str, stage: str) -> str:
+    """Execute one stage of a run, then enqueue whatever follows it.
+
+    One arq job per stage rather than per entity: the services already fan out
+    internally under their own semaphores and the shared token rate limiter, and
+    max_jobs = 1 exists to keep that the real concurrency control. Per-entity
+    resumption comes from the task rows, not from the queue.
+    """
+    from app.db.models import PipelineRun
+    from app.db.session import session_scope
+    from app.pipeline.control import cancel_checker
+    from app.pipeline.executor import execute_stage
+    from app.pipeline.registry import spec_for
+    from app.pipeline.runs import ensure_stages, stage_row
+    from app.pipeline.sequence import next_stage
+    from app.pipeline.stages import PipelineRunStatus, PipelineStageName, PipelineStageStatus
+    from app.pipeline.state import StageOutcome
+    from app.tasks.queue import task_queue
+
+    stage_name = PipelineStageName(stage)
+
+    with session_scope() as db:
+        run = db.get(PipelineRun, run_id)
+        if run is None:
+            logger.error("Run %s no longer exists; nothing to execute", run_id)
+            return StageOutcome.CANCELLED.value
+
+        ensure_stages(db, run)
+        row = stage_row(db, run, stage_name)
+        spec = spec_for(stage_name)
+
+        if spec is None:
+            # An unconverted stage is skipped rather than treated as failed, so
+            # the chain still reaches the stages that are converted.
+            row.status = PipelineStageStatus.SKIPPED
+            outcome = StageOutcome.COMPLETE
+        else:
+            run.status = PipelineRunStatus.RUNNING
+            outcome = await execute_stage(db, run, row, spec, is_cancelled=cancel_checker(run.id))
+
+        following = next_stage(stage_name)
+        if outcome is not StageOutcome.COMPLETE:
+            logger.info("Run %s stopped at %s: %s", run_id, stage, outcome.value)
+            return outcome.value
+
+        if following is None:
+            run.status = PipelineRunStatus.COMPLETED
+            run.finished_at = datetime.now(timezone.utc).replace(tzinfo=None)
+            logger.info("Run %s completed", run_id)
+            return outcome.value
+
+    # Enqueued outside the session: the next stage is minutes of work and has no
+    # business inheriting this one's connection.
+    await task_queue.enqueue("run_stage", run_id=run_id, stage=following.value)
+    return outcome.value
+
+
 # Registered with the worker. Kept as an explicit list so that adding a task
 # without registering it is a visible omission rather than a silent one.
 TASKS = [
+    run_stage,
     extract_linkedin_profile,
     update_linkedin_profiles,
     update_companies,
-    classify_alumni_roles,
     classify_alumni_seniority,
     resolve_role_locations,
     resolve_alumni_role_locations,

--- a/agents-api/app/tasks/worker.py
+++ b/agents-api/app/tasks/worker.py
@@ -21,6 +21,16 @@ async def startup(ctx) -> None:
         level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+
+    # A worker killed mid-stage leaves its in-flight tasks in RUNNING with
+    # nothing to move them. Sweeping on startup is what turns a hard kill into
+    # a resumable run rather than a stuck one.
+    from app.db.session import session_scope
+    from app.pipeline.recovery import recover_stuck_tasks
+
+    with session_scope() as db:
+        recover_stuck_tasks(db)
+
     logger.info("Worker started")
 
 

--- a/agents-api/app/tasks/worker.py
+++ b/agents-api/app/tasks/worker.py
@@ -22,22 +22,32 @@ async def startup(ctx) -> None:
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
+    # run_stage enqueues the following stage, so the worker needs its own pool.
+    # The API opens one in its lifespan; a worker never runs that, so without
+    # this every stage transition dies with QueueUnavailable and the chain stops
+    # after its first stage.
+    from app.db.session import session_scope
+    from app.pipeline.recovery import recover_stuck_tasks
+    from app.tasks.queue import task_queue
+
+    await task_queue.connect()
+
     # A worker killed mid-stage leaves its in-flight tasks in RUNNING with
     # nothing to move them. Sweeping on startup is what turns a hard kill into
     # a resumable run rather than a stuck one.
-    from app.db.session import session_scope
-    from app.pipeline.recovery import recover_stuck_tasks
-
     with session_scope() as db:
         recover_stuck_tasks(db)
+        db.commit()
 
     logger.info("Worker started")
 
 
 async def shutdown(ctx) -> None:
     from app.core.service_manager import service_manager
+    from app.tasks.queue import task_queue
 
     await service_manager.cleanup()
+    await task_queue.disconnect()
     logger.info("Worker stopped")
 
 

--- a/agents-api/tests/test_job_classification_service.py
+++ b/agents-api/tests/test_job_classification_service.py
@@ -1,0 +1,20 @@
+"""Error propagation out of the per-entity classification seam (CAR-157).
+
+The executor decides a task FAILED by catching what the handler raises. A
+service that logs and swallows makes every task look successful, which quietly
+disables the failure threshold and the abort path with it.
+"""
+
+import pytest
+
+from app.services.job_classification import job_classification_service
+
+
+async def test_classify_roles_for_alumni_propagates_failures(monkeypatch):
+    def blow_up(alumni_id, db):
+        raise RuntimeError("database went away")
+
+    monkeypatch.setattr("app.services.job_classification.get_extended_roles_by_alumni_id", blow_up)
+
+    with pytest.raises(RuntimeError, match="database went away"):
+        await job_classification_service.classify_roles_for_alumni("alumni-1")

--- a/agents-api/tests/test_pipeline_control.py
+++ b/agents-api/tests/test_pipeline_control.py
@@ -1,0 +1,77 @@
+"""The cancellation flag (CAR-157).
+
+Hermetic: the Redis client is injected, following the pattern `rate_limiter`
+already uses. What matters is the protocol - a key set, seen, and cleared - not
+that Redis itself works.
+"""
+
+import pytest
+
+from app.pipeline.control import (
+    CANCEL_KEY_TTL,
+    cancel_checker,
+    clear_cancel,
+    is_cancelled,
+    request_cancel,
+)
+
+
+class FakeRedis:
+    """Just enough of the client surface, recording what it was asked to do."""
+
+    def __init__(self):
+        self.store = {}
+        self.expiries = {}
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+        self.expiries[key] = ttl
+
+    def exists(self, key):
+        return 1 if key in self.store else 0
+
+    def delete(self, key):
+        self.store.pop(key, None)
+        self.expiries.pop(key, None)
+
+
+@pytest.fixture
+def client():
+    return FakeRedis()
+
+
+class TestCancelFlag:
+    def test_a_run_is_not_cancelled_by_default(self, client):
+        assert is_cancelled("run-1", client) is False
+
+    def test_requesting_cancel_makes_it_visible(self, client):
+        request_cancel("run-1", client)
+        assert is_cancelled("run-1", client) is True
+
+    def test_cancelling_one_run_does_not_cancel_another(self, client):
+        request_cancel("run-1", client)
+        assert is_cancelled("run-2", client) is False
+
+    def test_the_flag_expires(self, client):
+        # Without a TTL every cancelled run leaves a key behind forever, and
+        # a run id is never reused to clean it up.
+        request_cancel("run-1", client)
+        assert client.expiries["pipeline:cancel:run-1"] == CANCEL_KEY_TTL
+
+    def test_clearing_lets_the_run_be_restarted(self, client):
+        # A resume after a cancel has to clear the flag, or the resumed run
+        # stops at its first chunk for a cancellation that already happened.
+        request_cancel("run-1", client)
+        clear_cancel("run-1", client)
+        assert is_cancelled("run-1", client) is False
+
+
+class TestCancelChecker:
+    async def test_reports_the_current_flag_each_time_it_is_called(self, client):
+        # The executor calls this once per chunk, so it has to observe a cancel
+        # that arrives mid-stage rather than capturing the value up front.
+        check = cancel_checker("run-1", client)
+
+        assert await check() is False
+        request_cancel("run-1", client)
+        assert await check() is True

--- a/agents-api/tests/test_pipeline_executor.py
+++ b/agents-api/tests/test_pipeline_executor.py
@@ -9,6 +9,7 @@ stubbing the database out would test nothing.
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from sqlalchemy import event
 
 from app.db.models import PipelineRun, PipelineStage, PipelineTask
 from app.pipeline.executor import (
@@ -375,3 +376,33 @@ class TestRecoverStuckTasks:
 
         assert recover_stuck_tasks(db, timeout=timedelta(hours=8)) == 0
         assert _statuses(db, stage.id)["a"] is PipelineTaskStatus.SUCCEEDED
+
+
+class TestDurability:
+    """session_scope does not commit (app/db/session.py), so the executor must.
+
+    Without this every status write is discarded when the worker's session
+    closes, and a killed worker resumes from nothing - which defeats the whole
+    ticket. The `db` fixture cannot see the difference, because flushed and
+    committed state look identical inside its outer transaction; listening for
+    real commit events is what distinguishes them.
+    """
+
+    async def test_commits_at_chunk_boundaries(self, db, run, stage):
+        commits = []
+        event.listen(db, "after_commit", lambda s: commits.append(1))
+
+        async def handle(entity_id):
+            return None
+
+        spec = StageSpec(
+            entity_type=PipelineEntityType.ALUMNI,
+            resolve=lambda session, run: ["a", "b", "c", "d"],
+            handle=handle,
+            chunk_size=2,
+        )
+        await execute_stage(db, run, stage, spec)
+
+        # Two chunks, so progress must be durable at least twice - not once at
+        # the end, which would lose a whole stage to a kill.
+        assert len(commits) >= 2

--- a/agents-api/tests/test_pipeline_executor.py
+++ b/agents-api/tests/test_pipeline_executor.py
@@ -6,6 +6,8 @@ whether a resume reuses them, whether a crash leaves them recoverable - so
 stubbing the database out would test nothing.
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from app.db.models import PipelineRun, PipelineStage, PipelineTask
@@ -17,6 +19,7 @@ from app.pipeline.executor import (
     pending_entity_ids,
 )
 from app.pipeline.keys import idempotency_key
+from app.pipeline.recovery import recover_stuck_tasks
 from app.pipeline.stages import (
     PipelineEntityType,
     PipelineKind,
@@ -291,3 +294,84 @@ class TestExecuteStage:
         db.refresh(stage)
         assert stage.status is PipelineStageStatus.FAILED
         assert stage.error is not None and "threshold" in stage.error.lower()
+
+
+class TestRunningMarker:
+    async def test_marks_a_chunk_running_before_handling_it(self, db, run, stage):
+        seen = {}
+
+        async def handle(entity_id):
+            seen[entity_id] = (
+                db.query(PipelineTask).filter(PipelineTask.entity_id == entity_id).one().status
+            )
+            return None
+
+        spec = StageSpec(
+            entity_type=PipelineEntityType.ALUMNI,
+            resolve=lambda session, run: ["a", "b"],
+            handle=handle,
+            chunk_size=2,
+        )
+        await execute_stage(db, run, stage, spec)
+
+        # Without this the crash-recovery sweep has nothing to find: a killed
+        # worker would leave rows in QUEUED, indistinguishable from work that
+        # was never started.
+        assert seen == {"a": PipelineTaskStatus.RUNNING, "b": PipelineTaskStatus.RUNNING}
+
+    async def test_only_the_current_chunk_is_marked_running(self, db, run, stage):
+        seen = []
+
+        async def handle(entity_id):
+            seen.append(db.query(PipelineTask).filter(PipelineTask.entity_id == "d").one().status)
+            return None
+
+        spec = StageSpec(
+            entity_type=PipelineEntityType.ALUMNI,
+            resolve=lambda session, run: ["a", "b", "c", "d"],
+            handle=handle,
+            chunk_size=2,
+        )
+        await execute_stage(db, run, stage, spec)
+
+        # While the first chunk runs, "d" is still queued.
+        assert seen[0] is PipelineTaskStatus.QUEUED
+
+
+class TestRecoverStuckTasks:
+    def test_resets_tasks_left_running_by_a_dead_worker(self, db, run, stage):
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+        task = db.query(PipelineTask).filter(PipelineTask.entity_id == "a").one()
+        task.status = PipelineTaskStatus.RUNNING
+        task.started_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=9)
+        db.flush()
+
+        reset = recover_stuck_tasks(db, timeout=timedelta(hours=8))
+        db.flush()
+
+        assert reset == 1
+        assert _statuses(db, stage.id)["a"] is PipelineTaskStatus.QUEUED
+
+    def test_leaves_tasks_that_are_still_within_the_timeout(self, db, run, stage):
+        # A long-running stage is normal here - request_role_location sleeps 60s
+        # between batches. Resetting live work would double-process it.
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+        task = db.query(PipelineTask).filter(PipelineTask.entity_id == "a").one()
+        task.status = PipelineTaskStatus.RUNNING
+        task.started_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=5)
+        db.flush()
+
+        assert recover_stuck_tasks(db, timeout=timedelta(hours=8)) == 0
+
+    def test_leaves_terminal_tasks_alone(self, db, run, stage):
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+        task = db.query(PipelineTask).filter(PipelineTask.entity_id == "a").one()
+        task.status = PipelineTaskStatus.SUCCEEDED
+        task.started_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=2)
+        db.flush()
+
+        assert recover_stuck_tasks(db, timeout=timedelta(hours=8)) == 0
+        assert _statuses(db, stage.id)["a"] is PipelineTaskStatus.SUCCEEDED

--- a/agents-api/tests/test_pipeline_executor.py
+++ b/agents-api/tests/test_pipeline_executor.py
@@ -1,0 +1,293 @@
+"""Executor behaviour against a real database (CAR-157).
+
+These use the `db` fixture, so they need Postgres with the Prisma schema applied
+and are skipped locally without it. The behaviour under test *is* the rows -
+whether a resume reuses them, whether a crash leaves them recoverable - so
+stubbing the database out would test nothing.
+"""
+
+import pytest
+
+from app.db.models import PipelineRun, PipelineStage, PipelineTask
+from app.pipeline.executor import (
+    StageSpec,
+    count_tasks,
+    execute_stage,
+    materialize_tasks,
+    pending_entity_ids,
+)
+from app.pipeline.keys import idempotency_key
+from app.pipeline.stages import (
+    PipelineEntityType,
+    PipelineKind,
+    PipelineStageName,
+    PipelineStageStatus,
+    PipelineTaskStatus,
+)
+from app.pipeline.state import StageOutcome
+
+
+@pytest.fixture
+def run(db):
+    r = PipelineRun(kind=PipelineKind.REFRESH_EXISTING)
+    db.add(r)
+    db.flush()
+    return r
+
+
+@pytest.fixture
+def stage(db, run):
+    s = PipelineStage(run_id=run.id, stage=PipelineStageName.CLASSIFY_ROLES, sequence=3)
+    db.add(s)
+    db.flush()
+    return s
+
+
+def _statuses(db, stage_id):
+    rows = db.query(PipelineTask).filter(PipelineTask.stage_id == stage_id).all()
+    return {row.entity_id: row.status for row in rows}
+
+
+class TestMaterializeTasks:
+    def test_creates_one_queued_task_per_entity(self, db, run, stage):
+        materialize_tasks(db, run, stage, ["a", "b", "c"], PipelineEntityType.ALUMNI)
+        db.flush()
+
+        assert _statuses(db, stage.id) == {
+            "a": PipelineTaskStatus.QUEUED,
+            "b": PipelineTaskStatus.QUEUED,
+            "c": PipelineTaskStatus.QUEUED,
+        }
+
+    def test_derives_the_shared_idempotency_key(self, db, run, stage):
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+
+        task = db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).one()
+        assert task.idempotency_key == idempotency_key(
+            run.id, PipelineStageName.CLASSIFY_ROLES, "a"
+        )
+
+    def test_is_idempotent(self, db, run, stage):
+        # A resumed stage re-materializes before running. Without ON CONFLICT
+        # this raises on the unique constraint and the resume dies on contact.
+        materialize_tasks(db, run, stage, ["a", "b"], PipelineEntityType.ALUMNI)
+        db.flush()
+        created = materialize_tasks(db, run, stage, ["a", "b"], PipelineEntityType.ALUMNI)
+        db.flush()
+
+        assert created == 0
+        assert len(_statuses(db, stage.id)) == 2
+
+    def test_does_not_reset_work_that_already_succeeded(self, db, run, stage):
+        # The whole point of resume-at-stage: re-materializing must not drag a
+        # finished task back to QUEUED and pay for it twice.
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+        task = db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).one()
+        task.status = PipelineTaskStatus.SUCCEEDED
+        db.flush()
+
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+
+        assert _statuses(db, stage.id) == {"a": PipelineTaskStatus.SUCCEEDED}
+
+    def test_adds_only_the_new_entities(self, db, run, stage):
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+        created = materialize_tasks(db, run, stage, ["a", "b"], PipelineEntityType.ALUMNI)
+        db.flush()
+
+        assert created == 1
+        assert set(_statuses(db, stage.id)) == {"a", "b"}
+
+
+class TestCountTasks:
+    def test_counts_by_status(self, db, run, stage):
+        materialize_tasks(db, run, stage, ["a", "b", "c", "d"], PipelineEntityType.ALUMNI)
+        db.flush()
+        rows = db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).all()
+        by_entity = {row.entity_id: row for row in rows}
+        by_entity["a"].status = PipelineTaskStatus.SUCCEEDED
+        by_entity["b"].status = PipelineTaskStatus.FAILED
+        by_entity["c"].status = PipelineTaskStatus.SKIPPED
+        db.flush()
+
+        counts = count_tasks(db, stage.id)
+
+        assert (counts.total, counts.succeeded, counts.failed, counts.skipped) == (4, 1, 1, 1)
+        assert counts.pending == 1
+
+    def test_an_empty_stage_counts_zero(self, db, stage):
+        assert count_tasks(db, stage.id).total == 0
+
+
+class TestPendingEntityIds:
+    def test_excludes_succeeded_entities(self, db, run, stage):
+        materialize_tasks(db, run, stage, ["a", "b"], PipelineEntityType.ALUMNI)
+        db.flush()
+        rows = db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).all()
+        {row.entity_id: row for row in rows}["a"].status = PipelineTaskStatus.SUCCEEDED
+        db.flush()
+
+        assert pending_entity_ids(db, stage.id) == ["b"]
+
+    def test_includes_failed_entities_so_a_resume_retries_them(self, db, run, stage):
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+        db.query(PipelineTask).filter(
+            PipelineTask.stage_id == stage.id
+        ).one().status = PipelineTaskStatus.FAILED
+        db.flush()
+
+        assert pending_entity_ids(db, stage.id) == ["a"]
+
+    def test_excludes_skipped_entities(self, db, run, stage):
+        # SKIPPED is a decision already taken about that entity, not unfinished
+        # work. Retrying it would re-litigate the decision on every resume.
+        materialize_tasks(db, run, stage, ["a"], PipelineEntityType.ALUMNI)
+        db.flush()
+        db.query(PipelineTask).filter(
+            PipelineTask.stage_id == stage.id
+        ).one().status = PipelineTaskStatus.SKIPPED
+        db.flush()
+
+        assert pending_entity_ids(db, stage.id) == []
+
+
+class TestExecuteStage:
+    def _spec(self, handle, chunk_size=2):
+        return StageSpec(
+            entity_type=PipelineEntityType.ALUMNI,
+            resolve=lambda session, run: ["a", "b", "c", "d"],
+            handle=handle,
+            chunk_size=chunk_size,
+        )
+
+    async def test_marks_each_handled_entity_succeeded(self, db, run, stage):
+        async def handle(entity_id):
+            return {"seen": entity_id}
+
+        outcome = await execute_stage(db, run, stage, self._spec(handle))
+
+        assert outcome is StageOutcome.COMPLETE
+        assert set(_statuses(db, stage.id).values()) == {PipelineTaskStatus.SUCCEEDED}
+
+    async def test_records_the_handler_result_on_the_task(self, db, run, stage):
+        # CAR-155 sized `result` to hold what the model decided, which is the
+        # baseline CAR-106 and CAR-108 need to prove an improvement against.
+        async def handle(entity_id):
+            return {"esco": "2512.3", "confidence": 0.91}
+
+        await execute_stage(db, run, stage, self._spec(handle))
+
+        task = db.query(PipelineTask).filter(PipelineTask.entity_id == "a").one()
+        assert task.result == {"esco": "2512.3", "confidence": 0.91}
+
+    async def test_a_failing_entity_does_not_stop_the_others(self, db, run, stage):
+        async def handle(entity_id):
+            if entity_id == "b":
+                raise RuntimeError("provider blew up")
+            return None
+
+        await execute_stage(db, run, stage, self._spec(handle))
+
+        statuses = _statuses(db, stage.id)
+        assert statuses["b"] is PipelineTaskStatus.FAILED
+        assert statuses["a"] is PipelineTaskStatus.SUCCEEDED
+        assert statuses["d"] is PipelineTaskStatus.SUCCEEDED
+
+    async def test_records_why_a_task_failed(self, db, run, stage):
+        async def handle(entity_id):
+            raise RuntimeError("provider blew up")
+
+        await execute_stage(db, run, stage, self._spec(handle))
+
+        task = db.query(PipelineTask).filter(PipelineTask.entity_id == "a").one()
+        assert "provider blew up" in task.error
+
+    async def test_counts_are_flushed_to_the_stage_row(self, db, run, stage):
+        async def handle(entity_id):
+            if entity_id == "b":
+                raise RuntimeError("nope")
+            return None
+
+        await execute_stage(db, run, stage, self._spec(handle))
+
+        db.refresh(stage)
+        assert (stage.succeeded_count, stage.failed_count, stage.total_count) == (3, 1, 4)
+
+    async def test_does_not_rerun_entities_that_already_succeeded(self, db, run, stage):
+        attempted = []
+
+        async def handle(entity_id):
+            attempted.append(entity_id)
+            return None
+
+        materialize_tasks(db, run, stage, ["a", "b", "c", "d"], PipelineEntityType.ALUMNI)
+        db.flush()
+        db.query(PipelineTask).filter(
+            PipelineTask.entity_id == "a"
+        ).one().status = PipelineTaskStatus.SUCCEEDED
+        db.flush()
+
+        await execute_stage(db, run, stage, self._spec(handle))
+
+        assert "a" not in attempted
+        assert set(attempted) == {"b", "c", "d"}
+
+    async def test_stops_when_cancelled_between_chunks(self, db, run, stage):
+        attempted = []
+
+        async def handle(entity_id):
+            attempted.append(entity_id)
+            return None
+
+        # Cancelled once the first chunk of two has been handled.
+        async def is_cancelled():
+            return len(attempted) >= 2
+
+        outcome = await execute_stage(db, run, stage, self._spec(handle), is_cancelled=is_cancelled)
+
+        assert outcome is StageOutcome.CANCELLED
+        assert len(attempted) == 2
+        assert _statuses(db, stage.id)["d"] is PipelineTaskStatus.QUEUED
+
+    async def test_aborts_once_the_failure_threshold_is_exceeded(self, db, run, stage):
+        attempted = []
+
+        async def handle(entity_id):
+            attempted.append(entity_id)
+            raise RuntimeError("everything is failing")
+
+        entity_ids = [str(i) for i in range(100)]
+        spec = StageSpec(
+            entity_type=PipelineEntityType.ALUMNI,
+            resolve=lambda session, run: entity_ids,
+            handle=handle,
+            chunk_size=25,
+        )
+
+        outcome = await execute_stage(db, run, stage, spec)
+
+        # Stopped at a chunk boundary rather than grinding through all 100.
+        assert outcome is StageOutcome.ABORT_THRESHOLD
+        assert len(attempted) < len(entity_ids)
+
+    async def test_an_aborted_stage_records_the_reason(self, db, run, stage):
+        async def handle(entity_id):
+            raise RuntimeError("everything is failing")
+
+        spec = StageSpec(
+            entity_type=PipelineEntityType.ALUMNI,
+            resolve=lambda session, run: [str(i) for i in range(100)],
+            handle=handle,
+            chunk_size=25,
+        )
+
+        await execute_stage(db, run, stage, spec)
+
+        db.refresh(stage)
+        assert stage.status is PipelineStageStatus.FAILED
+        assert stage.error is not None and "threshold" in stage.error.lower()

--- a/agents-api/tests/test_pipeline_run_stage.py
+++ b/agents-api/tests/test_pipeline_run_stage.py
@@ -1,0 +1,180 @@
+"""Orchestration in the run_stage task (CAR-157).
+
+The executor is covered in test_pipeline_executor; what is tested here is what
+run_stage does *around* it - which stage runs next, when the run is finished,
+and when nothing should be enqueued at all. That seam was previously only
+exercised by hand.
+
+session_scope is patched to hand back the test session, so these run inside the
+`db` fixture's transaction rather than against whatever DATABASE_URL points at.
+"""
+
+from contextlib import contextmanager
+
+import pytest
+
+from app.db.models import PipelineRun, PipelineStage, PipelineTask
+from app.pipeline.executor import StageSpec
+from app.pipeline.stages import (
+    PipelineEntityType,
+    PipelineKind,
+    PipelineRunStatus,
+    PipelineStageName,
+    PipelineStageStatus,
+    PipelineTaskStatus,
+)
+from app.tasks.pipeline import run_stage
+
+
+@pytest.fixture
+def run(db):
+    r = PipelineRun(kind=PipelineKind.REFRESH_EXISTING, status=PipelineRunStatus.PLANNING)
+    db.add(r)
+    db.flush()
+    return r
+
+
+@pytest.fixture
+def enqueued(db, monkeypatch):
+    """Patch out the process boundaries: session, queue and cancellation."""
+    from app.pipeline import control, registry
+    from app.tasks.queue import task_queue
+
+    @contextmanager
+    def fake_scope():
+        yield db
+
+    monkeypatch.setattr("app.db.session.session_scope", fake_scope)
+
+    calls = []
+
+    async def fake_enqueue(task, **kwargs):
+        calls.append((task, kwargs))
+        return "job-id"
+
+    monkeypatch.setattr(task_queue, "enqueue", fake_enqueue)
+
+    # Otherwise this builds a real Redis client from settings and the network
+    # guard trips on a test that has nothing to do with Redis.
+    def never_cancelled(run_id, client=None):
+        async def check():
+            return False
+
+        return check
+
+    monkeypatch.setattr(control, "cancel_checker", never_cancelled)
+
+    async def handle(entity_id):
+        return {"handled": entity_id}
+
+    monkeypatch.setitem(
+        registry.STAGES,
+        PipelineStageName.CLASSIFY_ROLES,
+        StageSpec(
+            entity_type=PipelineEntityType.ALUMNI,
+            resolve=lambda session, r: ["a", "b"],
+            handle=handle,
+            chunk_size=2,
+        ),
+    )
+    return calls
+
+
+def _stage(db, run_id, name):
+    return (
+        db.query(PipelineStage)
+        .filter(PipelineStage.run_id == run_id, PipelineStage.stage == name)
+        .one()
+    )
+
+
+class TestConvertedStage:
+    async def test_runs_the_stage_and_marks_its_tasks(self, db, run, enqueued):
+        await run_stage(None, run.id, PipelineStageName.CLASSIFY_ROLES.value)
+
+        stage = _stage(db, run.id, PipelineStageName.CLASSIFY_ROLES)
+        statuses = {
+            row.entity_id: row.status
+            for row in db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).all()
+        }
+        assert statuses == {
+            "a": PipelineTaskStatus.SUCCEEDED,
+            "b": PipelineTaskStatus.SUCCEEDED,
+        }
+
+    async def test_enqueues_the_following_stage(self, db, run, enqueued):
+        await run_stage(None, run.id, PipelineStageName.CLASSIFY_ROLES.value)
+
+        assert enqueued == [
+            ("run_stage", {"run_id": run.id, "stage": PipelineStageName.SENIORITY.value})
+        ]
+
+    async def test_marks_the_stage_completed(self, db, run, enqueued):
+        await run_stage(None, run.id, PipelineStageName.CLASSIFY_ROLES.value)
+
+        assert _stage(db, run.id, PipelineStageName.CLASSIFY_ROLES).status is (
+            PipelineStageStatus.COMPLETED
+        )
+
+
+class TestUnconvertedStage:
+    async def test_is_skipped_rather_than_failed(self, db, run, enqueued):
+        # Five of six stages are still on their old coarse tasks. Failing here
+        # would strand every run at LINKEDIN and never reach CLASSIFY_ROLES.
+        await run_stage(None, run.id, PipelineStageName.LINKEDIN.value)
+
+        assert _stage(db, run.id, PipelineStageName.LINKEDIN).status is (
+            PipelineStageStatus.SKIPPED
+        )
+
+    async def test_still_advances_the_chain(self, db, run, enqueued):
+        await run_stage(None, run.id, PipelineStageName.LINKEDIN.value)
+
+        assert enqueued == [
+            ("run_stage", {"run_id": run.id, "stage": PipelineStageName.COMPANY.value})
+        ]
+
+
+class TestLastStage:
+    async def test_completes_the_run(self, db, run, enqueued):
+        await run_stage(None, run.id, PipelineStageName.LOCATION.value)
+
+        assert run.status is PipelineRunStatus.COMPLETED
+        assert run.finished_at is not None
+
+    async def test_enqueues_nothing_further(self, db, run, enqueued):
+        await run_stage(None, run.id, PipelineStageName.LOCATION.value)
+
+        assert enqueued == []
+
+
+class TestStagesThatDoNotComplete:
+    async def test_a_cancelled_stage_does_not_advance_the_chain(
+        self, db, run, enqueued, monkeypatch
+    ):
+        from app.pipeline import control
+
+        def always_cancelled(run_id, client=None):
+            async def check():
+                return True
+
+            return check
+
+        monkeypatch.setattr(control, "cancel_checker", always_cancelled)
+
+        await run_stage(None, run.id, PipelineStageName.CLASSIFY_ROLES.value)
+
+        assert enqueued == []
+        assert run.status is PipelineRunStatus.CANCELLED
+
+
+class TestMissingRun:
+    async def test_reports_cancelled_and_enqueues_nothing(self, db, enqueued):
+        # A deleted run must not take the worker down, and must not enqueue a
+        # follow-on stage for something that no longer exists.
+        outcome = await run_stage(
+            None, "00000000-0000-0000-0000-000000000000", PipelineStageName.CLASSIFY_ROLES.value
+        )
+
+        assert outcome == "CANCELLED"
+        assert enqueued == []

--- a/agents-api/tests/test_pipeline_runs.py
+++ b/agents-api/tests/test_pipeline_runs.py
@@ -1,0 +1,186 @@
+"""Run lifecycle: creation, resume and cancel (CAR-157).
+
+The resume tests are acceptance criterion 2 - "re-runs only X onwards, and only
+its non-succeeded tasks" - so they assert on what survives a resume as much as
+on what it redoes.
+"""
+
+import pytest
+
+from app.db.models import PipelineStage, PipelineTask
+from app.pipeline.executor import materialize_tasks
+from app.pipeline.runs import cancel_run, create_run, ensure_stages, resume_run
+from app.pipeline.sequence import STAGE_SEQUENCE
+from app.pipeline.stages import (
+    PipelineEntityType,
+    PipelineKind,
+    PipelineRunStatus,
+    PipelineStageName,
+    PipelineStageStatus,
+    PipelineTaskStatus,
+)
+
+
+class StubRedis:
+    def __init__(self):
+        self.store = {}
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+
+    def exists(self, key):
+        return 1 if key in self.store else 0
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+
+@pytest.fixture
+def redis():
+    return StubRedis()
+
+
+def _stages(db, run_id):
+    rows = db.query(PipelineStage).filter(PipelineStage.run_id == run_id).all()
+    return {row.stage: row for row in rows}
+
+
+class TestCreateRun:
+    def test_starts_in_planning(self, db):
+        run = create_run(db, kind=PipelineKind.REFRESH_EXISTING)
+        db.flush()
+        assert run.status is PipelineRunStatus.PLANNING
+
+    def test_records_the_params_it_was_given(self, db):
+        run = create_run(db, kind=PipelineKind.REFRESH_EXISTING, params={"alumni_ids": ["a"]})
+        db.flush()
+        assert run.params == {"alumni_ids": ["a"]}
+
+
+class TestEnsureStages:
+    def test_creates_every_stage_in_order(self, db):
+        run = create_run(db, kind=PipelineKind.REFRESH_EXISTING)
+        db.flush()
+
+        ensure_stages(db, run)
+        db.flush()
+
+        stages = _stages(db, run.id)
+        assert set(stages) == set(STAGE_SEQUENCE)
+        assert [stages[name].sequence for name in STAGE_SEQUENCE] == list(
+            range(len(STAGE_SEQUENCE))
+        )
+
+    def test_is_idempotent(self, db):
+        run = create_run(db, kind=PipelineKind.REFRESH_EXISTING)
+        db.flush()
+
+        ensure_stages(db, run)
+        db.flush()
+        ensure_stages(db, run)
+        db.flush()
+
+        assert len(_stages(db, run.id)) == len(STAGE_SEQUENCE)
+
+
+class TestResumeRun:
+    @pytest.fixture
+    def prepared(self, db):
+        run = create_run(db, kind=PipelineKind.REFRESH_EXISTING)
+        db.flush()
+        ensure_stages(db, run)
+        db.flush()
+        stages = _stages(db, run.id)
+        for name in STAGE_SEQUENCE:
+            stages[name].status = PipelineStageStatus.COMPLETED
+        materialize_tasks(
+            db, run, stages[PipelineStageName.COMPANY], ["a", "b"], PipelineEntityType.COMPANY
+        )
+        db.flush()
+        tasks = {
+            row.entity_id: row
+            for row in db.query(PipelineTask)
+            .filter(PipelineTask.stage_id == stages[PipelineStageName.COMPANY].id)
+            .all()
+        }
+        tasks["a"].status = PipelineTaskStatus.SUCCEEDED
+        tasks["b"].status = PipelineTaskStatus.FAILED
+        db.flush()
+        return run, stages
+
+    def test_returns_the_stage_to_run(self, db, prepared, redis):
+        run, _ = prepared
+        assert resume_run(db, run, PipelineStageName.COMPANY, redis) is PipelineStageName.COMPANY
+
+    def test_reopens_the_target_stage_and_everything_after(self, db, prepared, redis):
+        run, _ = prepared
+
+        resume_run(db, run, PipelineStageName.COMPANY, redis)
+        db.flush()
+
+        stages = _stages(db, run.id)
+        for name in (
+            PipelineStageName.COMPANY,
+            PipelineStageName.CLASSIFY_ROLES,
+            PipelineStageName.SENIORITY,
+            PipelineStageName.LOCATION,
+        ):
+            assert stages[name].status is PipelineStageStatus.PENDING
+
+    def test_leaves_earlier_stages_completed(self, db, prepared, redis):
+        run, _ = prepared
+
+        resume_run(db, run, PipelineStageName.COMPANY, redis)
+        db.flush()
+
+        stages = _stages(db, run.id)
+        assert stages[PipelineStageName.PLAN].status is PipelineStageStatus.COMPLETED
+        assert stages[PipelineStageName.LINKEDIN].status is PipelineStageStatus.COMPLETED
+
+    def test_does_not_undo_tasks_that_succeeded(self, db, prepared, redis):
+        run, stages = prepared
+
+        resume_run(db, run, PipelineStageName.COMPANY, redis)
+        db.flush()
+
+        tasks = {
+            row.entity_id: row.status
+            for row in db.query(PipelineTask)
+            .filter(PipelineTask.stage_id == stages[PipelineStageName.COMPANY].id)
+            .all()
+        }
+        assert tasks["a"] is PipelineTaskStatus.SUCCEEDED
+        assert tasks["b"] is PipelineTaskStatus.FAILED
+
+    def test_puts_the_run_back_into_running(self, db, prepared, redis):
+        run, _ = prepared
+        run.status = PipelineRunStatus.FAILED
+
+        resume_run(db, run, PipelineStageName.COMPANY, redis)
+        db.flush()
+
+        assert run.status is PipelineRunStatus.RUNNING
+
+    def test_clears_a_previous_cancellation(self, db, prepared, redis):
+        # Without this the resumed run stops at its first chunk for a cancel
+        # that was already acted on.
+        run, _ = prepared
+        cancel_run(db, run, redis)
+        db.flush()
+
+        resume_run(db, run, PipelineStageName.COMPANY, redis)
+        db.flush()
+
+        assert redis.exists(f"pipeline:cancel:{run.id}") == 0
+
+
+class TestCancelRun:
+    def test_sets_the_flag_and_the_status(self, db, redis):
+        run = create_run(db, kind=PipelineKind.REFRESH_EXISTING)
+        db.flush()
+
+        cancel_run(db, run, redis)
+        db.flush()
+
+        assert redis.exists(f"pipeline:cancel:{run.id}") == 1
+        assert run.status is PipelineRunStatus.CANCELLED

--- a/agents-api/tests/test_pipeline_state.py
+++ b/agents-api/tests/test_pipeline_state.py
@@ -1,0 +1,165 @@
+"""Transition rules for the staged pipeline (CAR-157).
+
+These tests import nothing that touches a database, Redis or arq. That is the
+point: the stage machine is the part worth being certain about, and it is only
+worth being certain about if the certainty is cheap to re-establish on every
+push. `app.db` constructs an engine at import time, so importing the enums from
+there would drag the database into a test that has no business knowing about
+it - hence `app.pipeline.stages`.
+"""
+
+import pytest
+
+from app.pipeline.sequence import STAGE_SEQUENCE, next_stage, sequence_of
+from app.pipeline.stages import PipelineStageName
+from app.pipeline.state import (
+    MIN_SAMPLE_FOR_THRESHOLD,
+    StageOutcome,
+    TaskCounts,
+    resume_targets,
+    should_abort,
+    stage_outcome,
+)
+
+
+class TestStageSequence:
+    def test_sequence_is_the_documented_order(self):
+        assert STAGE_SEQUENCE == (
+            PipelineStageName.PLAN,
+            PipelineStageName.LINKEDIN,
+            PipelineStageName.COMPANY,
+            PipelineStageName.CLASSIFY_ROLES,
+            PipelineStageName.SENIORITY,
+            PipelineStageName.LOCATION,
+        )
+
+    def test_sequence_covers_every_stage(self):
+        # A stage added to the enum but not the sequence would silently never
+        # run, which is the kind of omission that only shows up in production.
+        assert set(STAGE_SEQUENCE) == set(PipelineStageName)
+
+    @pytest.mark.parametrize(
+        "current,expected",
+        [
+            (PipelineStageName.PLAN, PipelineStageName.LINKEDIN),
+            (PipelineStageName.LINKEDIN, PipelineStageName.COMPANY),
+            (PipelineStageName.COMPANY, PipelineStageName.CLASSIFY_ROLES),
+            (PipelineStageName.CLASSIFY_ROLES, PipelineStageName.SENIORITY),
+            (PipelineStageName.SENIORITY, PipelineStageName.LOCATION),
+        ],
+    )
+    def test_next_stage_advances_one_step(self, current, expected):
+        assert next_stage(current) == expected
+
+    def test_next_stage_is_none_at_the_end(self):
+        assert next_stage(PipelineStageName.LOCATION) is None
+
+    def test_sequence_of_matches_position(self):
+        assert sequence_of(PipelineStageName.PLAN) == 0
+        assert sequence_of(PipelineStageName.CLASSIFY_ROLES) == 3
+        assert sequence_of(PipelineStageName.LOCATION) == 5
+
+
+class TestTaskCounts:
+    def test_terminal_sums_the_finished_statuses(self):
+        counts = TaskCounts(total=10, succeeded=4, failed=2, skipped=1)
+        assert counts.terminal == 7
+
+    def test_pending_is_what_is_left(self):
+        counts = TaskCounts(total=10, succeeded=4, failed=2, skipped=1)
+        assert counts.pending == 3
+
+    def test_failure_rate_is_measured_against_terminal_not_total(self):
+        # Half of what has finished has failed, even though only a fifth of the
+        # stage has been attempted. Measuring against total would report 0.1 and
+        # hide a stage that is failing outright.
+        counts = TaskCounts(total=100, succeeded=10, failed=10, skipped=0)
+        assert counts.failure_rate == 0.5
+
+    def test_failure_rate_is_zero_before_anything_finishes(self):
+        assert TaskCounts(total=100, succeeded=0, failed=0, skipped=0).failure_rate == 0.0
+
+
+class TestShouldAbort:
+    def test_does_not_abort_below_the_threshold(self):
+        counts = TaskCounts(total=100, succeeded=90, failed=10, skipped=0)
+        assert should_abort(counts, threshold=0.2) is False
+
+    def test_aborts_above_the_threshold(self):
+        counts = TaskCounts(total=100, succeeded=60, failed=40, skipped=0)
+        assert should_abort(counts, threshold=0.2) is True
+
+    def test_threshold_is_exclusive(self):
+        # "abort if MORE than 20% fail" - exactly 20% keeps going.
+        counts = TaskCounts(total=100, succeeded=80, failed=20, skipped=0)
+        assert counts.failure_rate == 0.2
+        assert should_abort(counts, threshold=0.2) is False
+
+    def test_does_not_abort_on_a_small_sample(self):
+        # One failure out of one attempt is a 100% failure rate but proves
+        # nothing. Aborting a 3000-task run on it would be absurd.
+        counts = TaskCounts(total=3000, succeeded=0, failed=1, skipped=0)
+        assert counts.failure_rate == 1.0
+        assert should_abort(counts, threshold=0.2) is False
+
+    def test_aborts_once_the_sample_is_large_enough(self):
+        counts = TaskCounts(total=3000, succeeded=0, failed=MIN_SAMPLE_FOR_THRESHOLD, skipped=0)
+        assert should_abort(counts, threshold=0.2) is True
+
+    def test_skipped_tasks_count_as_sample_but_not_as_failures(self):
+        # A skipped task is a decision, not a fault - it should not drag the
+        # failure rate up, but it does mean the stage is making progress.
+        counts = TaskCounts(total=100, succeeded=0, failed=0, skipped=50)
+        assert counts.failure_rate == 0.0
+        assert should_abort(counts, threshold=0.2) is False
+
+    def test_a_threshold_of_zero_aborts_on_any_failure_once_sampled(self):
+        counts = TaskCounts(total=100, succeeded=MIN_SAMPLE_FOR_THRESHOLD, failed=1, skipped=0)
+        assert should_abort(counts, threshold=0.0) is True
+
+
+class TestStageOutcome:
+    def test_running_while_tasks_remain(self):
+        counts = TaskCounts(total=10, succeeded=5, failed=0, skipped=0)
+        assert stage_outcome(counts, threshold=0.2) is StageOutcome.RUNNING
+
+    def test_complete_when_every_task_is_terminal(self):
+        counts = TaskCounts(total=10, succeeded=8, failed=1, skipped=1)
+        assert stage_outcome(counts, threshold=0.2) is StageOutcome.COMPLETE
+
+    def test_complete_when_the_stage_has_no_work(self):
+        # An empty stage is done, not stuck. Returning RUNNING here would hang
+        # the run on a stage that will never produce another event.
+        counts = TaskCounts(total=0, succeeded=0, failed=0, skipped=0)
+        assert stage_outcome(counts, threshold=0.2) is StageOutcome.COMPLETE
+
+    def test_abort_takes_precedence_over_still_running(self):
+        counts = TaskCounts(total=1000, succeeded=10, failed=90, skipped=0)
+        assert stage_outcome(counts, threshold=0.2) is StageOutcome.ABORT_THRESHOLD
+
+    def test_abort_takes_precedence_over_complete(self):
+        # The stage finished, but it finished badly. The run must not advance to
+        # the next stage on top of mostly-failed input.
+        counts = TaskCounts(total=100, succeeded=20, failed=80, skipped=0)
+        assert stage_outcome(counts, threshold=0.2) is StageOutcome.ABORT_THRESHOLD
+
+
+class TestResumeTargets:
+    def test_resumes_from_the_named_stage_onwards(self):
+        assert resume_targets(PipelineStageName.COMPANY) == (
+            PipelineStageName.COMPANY,
+            PipelineStageName.CLASSIFY_ROLES,
+            PipelineStageName.SENIORITY,
+            PipelineStageName.LOCATION,
+        )
+
+    def test_earlier_stages_are_never_included(self):
+        targets = resume_targets(PipelineStageName.SENIORITY)
+        assert PipelineStageName.LINKEDIN not in targets
+        assert PipelineStageName.CLASSIFY_ROLES not in targets
+
+    def test_resuming_the_last_stage_targets_only_itself(self):
+        assert resume_targets(PipelineStageName.LOCATION) == (PipelineStageName.LOCATION,)
+
+    def test_resuming_the_first_stage_targets_everything(self):
+        assert resume_targets(PipelineStageName.PLAN) == STAGE_SEQUENCE

--- a/agents-api/tests/test_pipeline_state.py
+++ b/agents-api/tests/test_pipeline_state.py
@@ -10,6 +10,7 @@ it - hence `app.pipeline.stages`.
 
 import pytest
 
+from app.pipeline.keys import idempotency_key
 from app.pipeline.sequence import STAGE_SEQUENCE, next_stage, sequence_of
 from app.pipeline.stages import PipelineStageName
 from app.pipeline.state import (
@@ -163,3 +164,39 @@ class TestResumeTargets:
 
     def test_resuming_the_first_stage_targets_everything(self):
         assert resume_targets(PipelineStageName.PLAN) == STAGE_SEQUENCE
+
+
+class TestIdempotencyKey:
+    def test_is_stable_for_the_same_entity_in_the_same_stage(self):
+        # The dedup guarantee is a unique constraint on this value, so resuming
+        # a stage has to derive the identical key or it inserts a duplicate row
+        # for work that already succeeded.
+        first = idempotency_key("run-1", PipelineStageName.CLASSIFY_ROLES, "alumni-1")
+        second = idempotency_key("run-1", PipelineStageName.CLASSIFY_ROLES, "alumni-1")
+        assert first == second
+
+    def test_differs_across_entities(self):
+        assert idempotency_key(
+            "run-1", PipelineStageName.CLASSIFY_ROLES, "alumni-1"
+        ) != idempotency_key("run-1", PipelineStageName.CLASSIFY_ROLES, "alumni-2")
+
+    def test_differs_across_stages(self):
+        assert idempotency_key(
+            "run-1", PipelineStageName.CLASSIFY_ROLES, "alumni-1"
+        ) != idempotency_key("run-1", PipelineStageName.SENIORITY, "alumni-1")
+
+    def test_differs_across_runs(self):
+        # Two runs over the same alumni are legitimate - a refresh next month is
+        # not the same work as this month's. Scoping to the run is what keeps
+        # the constraint from rejecting it.
+        assert idempotency_key(
+            "run-1", PipelineStageName.CLASSIFY_ROLES, "alumni-1"
+        ) != idempotency_key("run-2", PipelineStageName.CLASSIFY_ROLES, "alumni-1")
+
+    def test_separator_cannot_be_forged_by_an_entity_id(self):
+        # Naive concatenation lets an entity id containing the separator collide
+        # with a different (run, stage, entity) triple.
+        assert (
+            idempotency_key("run", PipelineStageName.PLAN, "a:b")
+            != idempotency_key("run", PipelineStageName.PLAN, "a") + ":b"
+        )


### PR DESCRIPTION
Turns the pipeline from a fire-and-forget sequence of background tasks into an explicit staged state machine that can be resumed from any stage after a failure or restart.

Closes CAR-157.

## What is here

| Module | Role |
|---|---|
| `app/pipeline/stages.py` | Pipeline enums, importable without a database |
| `app/pipeline/sequence.py` | Stage order, `next_stage` |
| `app/pipeline/state.py` | Pure transition rules |
| `app/pipeline/keys.py` | Idempotency key derivation |
| `app/pipeline/executor.py` | Materialize, drive, checkpoint |
| `app/pipeline/runs.py` | `create_run`, `ensure_stages`, `resume_run`, `cancel_run` |
| `app/pipeline/control.py` | Cancellation flag |
| `app/pipeline/recovery.py` | Stuck-`RUNNING` sweep |
| `app/pipeline/registry.py` | `CLASSIFY_ROLES` wiring |

`state.py` imports nothing from `app.db`, `app.services`, `arq` or `redis`, so the rules deciding whether a run continues are tested in milliseconds with no infrastructure. `executor.py` is the only module aware of both sides.

## Design decisions worth reviewing

**One arq job per stage, not per entity.** The services already fan out internally under their own semaphores and the shared token rate limiter, and `max_jobs = 1` exists to keep that the real concurrency control. Per-entity jobs would have moved concurrency to the worker and broken the rate limiter. Per-entity resumption comes from the task rows instead, which is where it belongs.

**The pipeline enums moved out of `app/db/models.py`.** `app/db/__init__.py` imports `session`, which calls `create_engine` at module scope, so importing an enum from `app.db` constructs an engine as a side effect. `models.py` imports them back for its `Column` definitions, so the values keep one definition and Prisma stays the migration owner.

**Failure threshold semantics, which the ticket left open.** Failures are measured against tasks that have *finished*, not against the whole stage — against the whole stage, a run whose first hundred tasks all failed out of a thousand reports 10% and keeps paying for an endpoint that is down. That rate is ignored below 20 finished tasks, or the first failure reads as 100% and aborts a 3000-task run on one transient error.

**`classify_roles_for_alumni` now re-raises.** It logged and swallowed every exception, so the executor could never see a failure: nothing would be marked FAILED and the threshold and abort path were dead code. `request_alumni_classification`, still called by the LinkedIn service, gathers with `return_exceptions=True` so its behaviour is unchanged.

**The `classify_alumni_roles` task is removed, not left registered.** The reachability guard in `test_tasks.py` caught it: nothing enqueues it now that the endpoint creates a run, and a second entry point writing no run record is exactly the invisibility CAR-155 set out to end.

## Three bugs found by running it

None of these were catchable by the suite as it stood.

1. **Nothing was persisted.** `session_scope` deliberately does not commit (`app/db/session.py`, a CAR-115 decision). Every write here went through it. The endpoint created a run that vanished before the worker looked for it, and every status write inside `execute_stage` would have been discarded on session close — which makes resumption structurally impossible, since a killed worker resumes from nothing. The `db` fixture could not see this: inside its outer transaction, flushed and committed state are indistinguishable. The new durability test listens for real `after_commit` events instead. Commits are per chunk, since a stage is minutes to hours of work.

2. **The worker never opened its queue.** `run_stage` enqueues the following stage, but `TaskQueue.connect()` only ran in the API's lifespan. Every stage transition died with `QueueUnavailable`, so the chain would have stopped after its first stage.

3. **The `RUNNING` claim was not committed**, so it rolled back with the dead worker's session and left rows in `QUEUED`, where the recovery sweep cannot tell them from work never started.

## Verification

Run end to end against local Postgres and Redis with a stand-in handler, so no OpenAI calls and no writes outside `pipeline_*`:

```
seed 40 tasks -> worker runs -> HARD KILL
  after kill:  30 SUCCEEDED, 5 RUNNING (orphaned), 5 QUEUED
restart worker -> resume_run(CLASSIFY_ROLES)
  final:       40 SUCCEEDED,  attempts_histogram = {1: 40}
```

Every task attempted exactly once across the kill: nothing lost, nothing double-processed.

All four acceptance criteria met. The `run_stage` tests were written after the code, so they were mutation-checked rather than trusted — dropping the enqueue, marking an unconverted stage FAILED instead of SKIPPED, and ignoring a non-COMPLETE outcome each fail exactly the test meant to catch them.

```
155 passed, 2 xfailed
ruff check app/ --select F: clean
ruff check + format tests/: clean
```

## Scope and follow-ups

Only `CLASSIFY_ROLES` is converted. The other four endpoints keep their current coarse tasks, and an unconverted stage is skipped rather than failed so the chain still reaches the stages that are converted. `PLAN` keeps its slot for CAR-158.

- `resume_run` and `cancel_run` ship as functions; the `POST /runs/{id}/resume` and `/cancel` endpoints belong to CAR-159, which is blocked by this.
- A hard-killed worker does not resume on restart without an explicit resume call — arq holds the in-flight job lock for `job_timeout`. Tracked as CAR-172.
- CAR-173 adds the eval harness that makes `PipelineTask.result` measurable rather than merely stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YPiRLJUH3sP1gC13o1zYq
