### PR TITLE
feat(api): pipeline status and control endpoints (CAR-159)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,86 @@
+name: lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Same shape as agents-api-tests.yml: the paths filter lives on the job, not
+  # the trigger. A workflow that never runs never reports, and a required check
+  # that never reports blocks the PR forever. A skipped required job counts as
+  # satisfied.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            api:
+              - 'api/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/lint.yml'
+            app:
+              - 'app/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/lint.yml'
+
+  api:
+    name: lint api
+    needs: changes
+    if: needs.changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      # --filter installs this workspace and its dependencies only. A full
+      # install pulls the frontend's toolchain to lint the backend.
+      - run: pnpm install --frozen-lockfile --filter api...
+
+      # Prisma Client is generated, and oxlint resolves imports of it. Without
+      # this the lint fails on a missing @prisma/client rather than on anything
+      # a reviewer would care about.
+      - run: pnpm --filter api prisma:generate
+
+      - run: pnpm --filter api lint
+
+  app:
+    name: lint app
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --filter app...
+
+      # next lint reads next.config and the ESLint config, so it needs the app's
+      # own dependencies present but no build.
+      - run: pnpm --filter app lint

--- a/agents-api/app/api/endpoints/job_classification.py
+++ b/agents-api/app/api/endpoints/job_classification.py
@@ -3,9 +3,6 @@ from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from app.db.session import session_scope
-from app.pipeline.runs import create_run, ensure_stages
-from app.pipeline.stages import PipelineKind, PipelineStageName
 from app.schemas.job_classification import AlumniJobClassificationParams, EscoResult
 from app.tasks.queue import task_queue
 from app.utils.agents.esco_reference import search_esco_classifications
@@ -29,23 +26,10 @@ async def classify_job(
     try:
         logger.info(f"Requesting alumni role classification for {params.alumni_ids}")
 
-        with session_scope() as db:
-            run = create_run(
-                db,
-                kind=PipelineKind.REFRESH_EXISTING,
-                params={"alumni_ids": params.alumni_ids},
-            )
-            db.flush()
-            ensure_stages(db, run)
-            run_id = run.id
-            # session_scope does not commit. Without this the run is gone by the
-            # time the worker looks for it, and run_stage finds nothing.
-            db.commit()
-
-        await task_queue.enqueue(
-            "run_stage", run_id=run_id, stage=PipelineStageName.CLASSIFY_ROLES.value
-        )
-        return {"run_id": run_id}
+        # Starting a *run* is POST /api/pipelines/{kind}/runs. This stays the
+        # narrow "classify these alumni" trigger so there is one path that
+        # writes run records rather than two (CAR-159).
+        await task_queue.enqueue("classify_alumni_roles", alumni_ids=params.alumni_ids)
 
     except Exception as e:
         logger.error(f"Error requesting alumni role classification: {str(e)}")

--- a/agents-api/app/api/endpoints/pipelines.py
+++ b/agents-api/app/api/endpoints/pipelines.py
@@ -1,0 +1,235 @@
+"""Status and control over pipeline runs.
+
+Shaped so the phase-2 admin UI is additive: list, detail, drill, act. Sessions
+arrive via `Depends(get_db)` rather than being opened in the handler, so the
+request owns the transaction and tests can substitute one.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.db.models import PipelineRun, PipelineStage, PipelineTask
+from app.db.session import get_db
+from app.pipeline import queries
+from app.pipeline.cursor import decode_cursor
+from app.pipeline.runs import cancel_run, create_run, ensure_stages, resume_run
+from app.pipeline.sequence import STAGE_SEQUENCE
+from app.pipeline.stages import (
+    PipelineKind,
+    PipelineRunStatus,
+    PipelineStageName,
+    PipelineTaskStatus,
+)
+from app.schemas.pipeline import (
+    CreateRunRequest,
+    Page,
+    RunAction,
+    RunCreated,
+    RunDetail,
+    RunSummary,
+    StageSummary,
+    TaskCountsOut,
+    TaskSummary,
+)
+from app.tasks.queue import task_queue
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+DEFAULT_LIMIT = 25
+
+
+def _cursor_or_400(raw: Optional[str]):
+    if raw is None:
+        return None
+    try:
+        return decode_cursor(raw)
+    except ValueError as exc:
+        # A stale or hand-written cursor is the client's mistake; letting the
+        # ValueError escape would report it as a server error instead.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid cursor: {exc}"
+        ) from exc
+
+
+def _run_or_404(session: Session, run_id: str) -> PipelineRun:
+    run = session.get(PipelineRun, run_id)
+    if run is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Run {run_id} not found")
+    return run
+
+
+def _summary(run: PipelineRun, counts: dict) -> RunSummary:
+    return RunSummary(
+        id=run.id,
+        kind=run.kind,
+        status=run.status,
+        trigger_source=run.trigger_source,
+        triggered_by=run.triggered_by,
+        params=run.params,
+        created_at=run.created_at,
+        started_at=run.started_at,
+        finished_at=run.finished_at,
+        error=run.error,
+        counts=TaskCountsOut(**counts),
+    )
+
+
+def _stage_summary(stage: PipelineStage) -> StageSummary:
+    return StageSummary(
+        stage=stage.stage,
+        sequence=stage.sequence,
+        status=stage.status,
+        total_count=stage.total_count,
+        succeeded_count=stage.succeeded_count,
+        failed_count=stage.failed_count,
+        skipped_count=stage.skipped_count,
+        started_at=stage.started_at,
+        finished_at=stage.finished_at,
+        error=stage.error,
+    )
+
+
+def _task_summary(task: PipelineTask) -> TaskSummary:
+    return TaskSummary(
+        id=task.id,
+        entity_type=task.entity_type,
+        entity_id=task.entity_id,
+        status=task.status,
+        attempts=task.attempts,
+        error=task.error,
+        result=task.result,
+        started_at=task.started_at,
+        finished_at=task.finished_at,
+    )
+
+
+@router.post(
+    "/{kind}/runs",
+    response_model=RunCreated,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Create a run and start it",
+)
+async def create_pipeline_run(
+    kind: PipelineKind,
+    body: CreateRunRequest,
+    db: Session = Depends(get_db),
+) -> RunCreated:
+    params = body.model_dump(exclude_none=True)
+
+    run = create_run(db, kind=kind, params=params or None)
+    db.flush()
+    ensure_stages(db, run)
+    run_id = run.id
+    # get_db does not commit, and the worker resolves the run by id.
+    db.commit()
+
+    await task_queue.enqueue("run_stage", run_id=run_id, stage=STAGE_SEQUENCE[0].value)
+    return RunCreated(run_id=run_id)
+
+
+@router.get("/runs", response_model=Page[RunSummary], summary="List runs")
+def list_runs(
+    db: Session = Depends(get_db),
+    kind: Optional[PipelineKind] = None,
+    status_filter: Optional[PipelineRunStatus] = Query(None, alias="status"),
+    cursor: Optional[str] = None,
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=queries.MAX_LIMIT),
+) -> Page[RunSummary]:
+    runs, next_cursor = queries.list_runs(
+        db, limit=limit, cursor=_cursor_or_400(cursor), kind=kind, status=status_filter
+    )
+    counts = queries.run_task_counts_bulk(db, [run.id for run in runs])
+    return Page[RunSummary](
+        items=[_summary(run, counts[run.id]) for run in runs], next_cursor=next_cursor
+    )
+
+
+@router.get("/runs/{run_id}", response_model=RunDetail, summary="Run detail")
+def get_run(run_id: str, db: Session = Depends(get_db)) -> RunDetail:
+    run = _run_or_404(db, run_id)
+    return RunDetail(
+        **_summary(run, queries.run_task_counts(db, run_id)).model_dump(),
+        stages=[_stage_summary(stage) for stage in queries.run_stages(db, run_id)],
+    )
+
+
+@router.get(
+    "/runs/{run_id}/tasks",
+    response_model=Page[TaskSummary],
+    summary="Tasks in a run",
+)
+def list_run_tasks(
+    run_id: str,
+    db: Session = Depends(get_db),
+    status_filter: Optional[PipelineTaskStatus] = Query(None, alias="status"),
+    stage: Optional[PipelineStageName] = None,
+    cursor: Optional[str] = None,
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=queries.MAX_LIMIT),
+) -> Page[TaskSummary]:
+    _run_or_404(db, run_id)
+    tasks, next_cursor = queries.list_tasks(
+        db,
+        run_id,
+        limit=limit,
+        cursor=_cursor_or_400(cursor),
+        status=status_filter,
+        stage=stage,
+    )
+    return Page[TaskSummary](items=[_task_summary(task) for task in tasks], next_cursor=next_cursor)
+
+
+@router.post(
+    "/runs/{run_id}/retry",
+    response_model=RunAction,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Re-run only the tasks that failed",
+)
+async def retry_run(run_id: str, db: Session = Depends(get_db)) -> RunAction:
+    run = _run_or_404(db, run_id)
+
+    earliest = queries.requeue_failed_tasks(db, run.id)
+    if earliest is None:
+        return RunAction(run_id=run.id, enqueued_stage=None)
+
+    run.status = PipelineRunStatus.RUNNING
+    run.error = None
+    run.finished_at = None
+    db.commit()
+
+    await task_queue.enqueue("run_stage", run_id=run.id, stage=earliest.value)
+    return RunAction(run_id=run.id, enqueued_stage=earliest)
+
+
+@router.post(
+    "/runs/{run_id}/resume",
+    response_model=RunAction,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Reopen a stage and everything after it",
+)
+async def resume(
+    run_id: str,
+    from_stage: PipelineStageName = Query(..., description="Stage to resume from"),
+    db: Session = Depends(get_db),
+) -> RunAction:
+    run = _run_or_404(db, run_id)
+
+    stage = resume_run(db, run, from_stage)
+
+    await task_queue.enqueue("run_stage", run_id=run.id, stage=stage.value)
+    return RunAction(run_id=run.id, enqueued_stage=stage)
+
+
+@router.post(
+    "/runs/{run_id}/cancel",
+    response_model=RunAction,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Stop a run at its next chunk boundary",
+)
+def cancel(run_id: str, db: Session = Depends(get_db)) -> RunAction:
+    run = _run_or_404(db, run_id)
+    cancel_run(db, run)
+    return RunAction(run_id=run.id, enqueued_stage=None)

--- a/agents-api/app/api/routes.py
+++ b/agents-api/app/api/routes.py
@@ -6,6 +6,7 @@ from app.api.endpoints import (
     job_classification,
     linkedin,
     location,
+    pipelines,
     role,
     seniority,
     storage,
@@ -59,4 +60,10 @@ api_router.include_router(
     esco.router,
     prefix="/esco",
     tags=["ESCO"],
+)
+
+api_router.include_router(
+    pipelines.router,
+    prefix="/pipelines",
+    tags=["Pipelines"],
 )

--- a/agents-api/app/core/middlewares.py
+++ b/agents-api/app/core/middlewares.py
@@ -1,9 +1,9 @@
 import logging
 import time
 
-from fastapi import HTTPException, Request, status
+from fastapi import Request, status
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 from app.core.config import settings
 
@@ -50,6 +50,17 @@ class LoggingMiddleware(BaseHTTPMiddleware):
 PUBLIC_PATHS = {"/health"}
 
 
+def _unauthorized(detail: str) -> JSONResponse:
+    """Return the 401 rather than raising it.
+
+    An HTTPException raised inside a BaseHTTPMiddleware is not seen by FastAPI's
+    exception handler - that runs inside the router, further in - so it bubbles
+    to ServerErrorMiddleware and the client gets a 500. A missing API key would
+    have read as "the server broke" rather than "you are not authorised".
+    """
+    return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content={"detail": detail})
+
+
 class APIKeyMiddleware(BaseHTTPMiddleware):
     """
     Middleware to authenticate requests using an API key.
@@ -68,18 +79,12 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 logger.warning(
                     f"Unauthorized access attempt: Missing API key - {request.method} {request.url.path}"  # noqa: E501
                 )
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="API key missing",
-                )
+                return _unauthorized("API key missing")
 
             if api_key != settings.API_KEY_SECRET:
                 logger.warning(
                     f"Unauthorized access attempt: Invalid API key - {request.method} {request.url.path}"  # noqa: E501
                 )
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid API key",
-                )
+                return _unauthorized("Invalid API key")
 
         return await call_next(request)

--- a/agents-api/app/pipeline/cursor.py
+++ b/agents-api/app/pipeline/cursor.py
@@ -1,0 +1,60 @@
+"""Keyset pagination cursors.
+
+Opaque by design: clients pass back what they were given rather than a
+`created_at` and `id` pair, so the ordering can change without breaking an SDK
+that has already been generated and shipped (CAR-162).
+"""
+
+import base64
+import binascii
+from dataclasses import dataclass
+from datetime import datetime
+
+SEPARATOR = "|"
+
+
+@dataclass(frozen=True)
+class Cursor:
+    created_at: datetime
+    id: str
+
+
+def encode_cursor(cursor: Cursor) -> str:
+    # Length-prefixed rather than joined on the separator: an id containing the
+    # separator would otherwise decode into a different cursor entirely.
+    payload = f"{cursor.created_at.isoformat()}{SEPARATOR}{len(cursor.id)}{SEPARATOR}{cursor.id}"
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def decode_cursor(raw: str) -> Cursor:
+    """Parse a cursor, raising ValueError on anything malformed.
+
+    Callers turn that into a 400: a stale or hand-written cursor is a client
+    error, and letting it surface as an unhandled decode failure would report it
+    as a server one.
+    """
+    if not raw:
+        raise ValueError("Cursor is empty")
+
+    try:
+        padded = raw + "=" * (-len(raw) % 4)
+        payload = base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError, ValueError) as exc:
+        raise ValueError(f"Cursor is not valid base64: {exc}") from exc
+
+    timestamp, _, remainder = payload.partition(SEPARATOR)
+    length, _, identifier = remainder.partition(SEPARATOR)
+
+    if not timestamp or not length:
+        raise ValueError("Cursor is missing its fields")
+
+    try:
+        created_at = datetime.fromisoformat(timestamp)
+        expected = int(length)
+    except ValueError as exc:
+        raise ValueError(f"Cursor fields are malformed: {exc}") from exc
+
+    if len(identifier) != expected:
+        raise ValueError("Cursor id length does not match its prefix")
+
+    return Cursor(created_at=created_at, id=identifier)

--- a/agents-api/app/pipeline/queries.py
+++ b/agents-api/app/pipeline/queries.py
@@ -1,0 +1,165 @@
+"""Reads and bulk state changes behind the pipeline API.
+
+Kept out of the endpoint module so the routes stay a thin translation layer,
+the same split `executor.py` uses to keep its database access in one place.
+"""
+
+import logging
+from typing import List, Optional, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.db.models import PipelineRun, PipelineStage, PipelineTask
+from app.pipeline.cursor import Cursor, encode_cursor
+from app.pipeline.sequence import sequence_of
+from app.pipeline.stages import (
+    PipelineKind,
+    PipelineRunStatus,
+    PipelineStageName,
+    PipelineTaskStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_LIMIT = 100
+
+
+def _paginate(query, model, limit: int, cursor: Optional[Cursor]):
+    """Apply keyset ordering and return one page plus its next cursor.
+
+    One row beyond the limit is fetched rather than counted: a count over the
+    task table would be a second full scan on every page.
+    """
+    if cursor is not None:
+        query = query.filter(
+            (model.created_at < cursor.created_at)
+            | ((model.created_at == cursor.created_at) & (model.id < cursor.id))
+        )
+
+    rows = query.order_by(model.created_at.desc(), model.id.desc()).limit(limit + 1).all()
+
+    if len(rows) <= limit:
+        return rows, None
+
+    page = rows[:limit]
+    last = page[-1]
+    return page, encode_cursor(Cursor(created_at=last.created_at, id=last.id))
+
+
+def list_runs(
+    session: Session,
+    limit: int,
+    cursor: Optional[Cursor] = None,
+    kind: Optional[PipelineKind] = None,
+    status: Optional[PipelineRunStatus] = None,
+) -> Tuple[List[PipelineRun], Optional[str]]:
+    query = session.query(PipelineRun)
+    if kind is not None:
+        query = query.filter(PipelineRun.kind == kind)
+    if status is not None:
+        query = query.filter(PipelineRun.status == status)
+    return _paginate(query, PipelineRun, limit, cursor)
+
+
+def list_tasks(
+    session: Session,
+    run_id: str,
+    limit: int,
+    cursor: Optional[Cursor] = None,
+    status: Optional[PipelineTaskStatus] = None,
+    stage: Optional[PipelineStageName] = None,
+) -> Tuple[List[PipelineTask], Optional[str]]:
+    query = (
+        session.query(PipelineTask)
+        .join(PipelineStage, PipelineTask.stage_id == PipelineStage.id)
+        .filter(PipelineStage.run_id == run_id)
+    )
+    if status is not None:
+        query = query.filter(PipelineTask.status == status)
+    if stage is not None:
+        query = query.filter(PipelineStage.stage == stage)
+    return _paginate(query, PipelineTask, limit, cursor)
+
+
+def run_stages(session: Session, run_id: str) -> List[PipelineStage]:
+    return (
+        session.query(PipelineStage)
+        .filter(PipelineStage.run_id == run_id)
+        .order_by(PipelineStage.sequence)
+        .all()
+    )
+
+
+def _empty_counts() -> dict:
+    return {"total": 0, "succeeded": 0, "failed": 0, "skipped": 0, "pending": 0}
+
+
+def run_task_counts_bulk(session: Session, run_ids: List[str]) -> dict:
+    """Count tasks by status for several runs in one query.
+
+    Counted from the task rows rather than summed from PipelineStage's
+    counters: those are written by the executor, so a run that has been created
+    but not yet executed would report zero tasks while plainly having them. One
+    grouped query rather than one per run keeps the list endpoint off N+1.
+    """
+    counts = {run_id: _empty_counts() for run_id in run_ids}
+    if not run_ids:
+        return counts
+
+    rows = (
+        session.query(PipelineStage.run_id, PipelineTask.status, func.count())
+        .join(PipelineTask, PipelineTask.stage_id == PipelineStage.id)
+        .filter(PipelineStage.run_id.in_(run_ids))
+        .group_by(PipelineStage.run_id, PipelineTask.status)
+        .all()
+    )
+
+    for run_id, task_status, count in rows:
+        entry = counts[run_id]
+        entry["total"] += count
+        if task_status is PipelineTaskStatus.SUCCEEDED:
+            entry["succeeded"] += count
+        elif task_status is PipelineTaskStatus.FAILED:
+            entry["failed"] += count
+        elif task_status is PipelineTaskStatus.SKIPPED:
+            entry["skipped"] += count
+        else:
+            entry["pending"] += count
+
+    return counts
+
+
+def run_task_counts(session: Session, run_id: str) -> dict:
+    return run_task_counts_bulk(session, [run_id])[run_id]
+
+
+def requeue_failed_tasks(session: Session, run_id: str) -> Optional[PipelineStageName]:
+    """Return FAILED tasks to QUEUED and report the earliest stage to re-run.
+
+    Only FAILED moves. SUCCEEDED is the double-spend this endpoint exists to
+    avoid, and SKIPPED is a decision already taken about that entity.
+    """
+    stages = {stage.id: stage for stage in run_stages(session, run_id)}
+    if not stages:
+        return None
+
+    failed = (
+        session.query(PipelineTask)
+        .filter(
+            PipelineTask.stage_id.in_(stages.keys()),
+            PipelineTask.status == PipelineTaskStatus.FAILED,
+        )
+        .all()
+    )
+    if not failed:
+        return None
+
+    for task in failed:
+        task.status = PipelineTaskStatus.QUEUED
+        task.error = None
+        task.finished_at = None
+
+    earliest = min((stages[task.stage_id].stage for task in failed), key=sequence_of)
+    logger.info("Requeued %s failed task(s) on run %s from %s", len(failed), run_id, earliest)
+    return earliest

--- a/agents-api/app/schemas/pipeline.py
+++ b/agents-api/app/schemas/pipeline.py
@@ -1,0 +1,106 @@
+"""Request and response models for the pipeline API.
+
+Every field is typed because CAR-162 generates the TypeScript client from the
+OpenAPI schema FastAPI derives from these. An untyped response produces an
+`any`-typed SDK method, which is the pain CAR-79 documents on the NestJS side.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Generic, List, Optional, TypeVar
+
+from pydantic import BaseModel, Field
+
+from app.pipeline.stages import (
+    PipelineEntityType,
+    PipelineKind,
+    PipelineRunStatus,
+    PipelineStageName,
+    PipelineStageStatus,
+    PipelineTaskStatus,
+    PipelineTrigger,
+)
+
+ItemT = TypeVar("ItemT")
+
+
+class Page(BaseModel, Generic[ItemT]):
+    """A keyset page. FastAPI emits one named schema per instantiation."""
+
+    items: List[ItemT]
+    next_cursor: Optional[str] = Field(
+        None, description="Pass back as `cursor` for the next page. Absent on the last page."
+    )
+
+
+class TaskCountsOut(BaseModel):
+    total: int
+    succeeded: int
+    failed: int
+    skipped: int
+    pending: int
+
+
+class StageSummary(BaseModel):
+    stage: PipelineStageName
+    sequence: int
+    status: PipelineStageStatus
+    total_count: int
+    succeeded_count: int
+    failed_count: int
+    skipped_count: int
+    started_at: Optional[datetime]
+    finished_at: Optional[datetime]
+    error: Optional[str]
+
+
+class RunSummary(BaseModel):
+    id: str
+    kind: PipelineKind
+    status: PipelineRunStatus
+    trigger_source: PipelineTrigger
+    triggered_by: Optional[str]
+    params: Optional[Dict[str, Any]]
+    created_at: datetime
+    started_at: Optional[datetime]
+    finished_at: Optional[datetime]
+    error: Optional[str]
+    counts: TaskCountsOut
+
+
+class RunDetail(RunSummary):
+    stages: List[StageSummary]
+
+
+class TaskSummary(BaseModel):
+    id: str
+    entity_type: PipelineEntityType
+    entity_id: str
+    status: PipelineTaskStatus
+    attempts: int
+    error: Optional[str]
+    result: Optional[Dict[str, Any]]
+    started_at: Optional[datetime]
+    finished_at: Optional[datetime]
+
+
+class CreateRunRequest(BaseModel):
+    alumni_ids: Optional[str] = Field(
+        None, description="Comma-separated alumni IDs. All alumni in scope when omitted."
+    )
+    failure_threshold: Optional[float] = Field(
+        None,
+        ge=0.0,
+        le=1.0,
+        description="Abort the run above this share of failed tasks. Defaults to 0.2.",
+    )
+
+
+class RunCreated(BaseModel):
+    run_id: str
+
+
+class RunAction(BaseModel):
+    run_id: str
+    enqueued_stage: Optional[PipelineStageName] = Field(
+        None, description="The stage put on the queue, if any work needed doing."
+    )

--- a/agents-api/app/tasks/pipeline.py
+++ b/agents-api/app/tasks/pipeline.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 
 from app.schemas.company import CompanyUpdateParams
+from app.schemas.job_classification import AlumniJobClassificationParams
 from app.schemas.location import ResolveRoleLocationParams
 from app.schemas.seniority import AlumniSeniorityParams
 
@@ -44,9 +45,12 @@ async def update_companies(ctx, company_ids: Optional[str] = None) -> None:
     await company_service.request_company_update(CompanyUpdateParams(company_ids=company_ids))
 
 
-# classify_alumni_roles is gone: the CLASSIFY_ROLES stage now owns that path, so
-# leaving the task registered would be one more entry point writing no run
-# record. The service method it called is still used by the LinkedIn service.
+async def classify_alumni_roles(ctx, alumni_ids: Optional[str] = None) -> None:
+    from app.services.job_classification import job_classification_service
+
+    await job_classification_service.request_alumni_classification(
+        params=AlumniJobClassificationParams(alumni_ids=alumni_ids)
+    )
 
 
 async def classify_alumni_seniority(ctx, alumni_ids: Optional[str] = None) -> None:
@@ -133,6 +137,7 @@ async def run_stage(ctx, run_id: str, stage: str) -> str:
 TASKS = [
     run_stage,
     extract_linkedin_profile,
+    classify_alumni_roles,
     update_linkedin_profiles,
     update_companies,
     classify_alumni_seniority,

--- a/agents-api/tests/test_pipeline_cursor.py
+++ b/agents-api/tests/test_pipeline_cursor.py
@@ -1,0 +1,54 @@
+"""Keyset cursor encoding (CAR-159).
+
+The cursor is opaque to clients, which is the point: encoding it rather than
+exposing `created_at` and `id` as query params means the ordering can change
+later without breaking a generated SDK that has already shipped.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from app.pipeline.cursor import Cursor, decode_cursor, encode_cursor
+
+
+class TestRoundTrip:
+    def test_survives_encoding(self):
+        original = Cursor(created_at=datetime(2026, 8, 16, 12, 30, 45, 123456), id="abc-123")
+        assert decode_cursor(encode_cursor(original)) == original
+
+    def test_preserves_microseconds(self):
+        # Runs created in the same second are common when a batch is seeded, so
+        # truncating here would make the tiebreak do all the work and paging
+        # would start skipping rows.
+        original = Cursor(created_at=datetime(2026, 8, 16, 12, 30, 45, 999999), id="x")
+        assert decode_cursor(encode_cursor(original)).created_at.microsecond == 999999
+
+    def test_is_opaque(self):
+        encoded = encode_cursor(Cursor(created_at=datetime(2026, 8, 16), id="abc-123"))
+        assert "abc-123" not in encoded
+        assert "2026" not in encoded
+
+    def test_is_url_safe(self):
+        # It travels as a query parameter, so + and / would need escaping and
+        # would eventually be mangled by something in the chain.
+        encoded = encode_cursor(
+            Cursor(created_at=datetime(2026, 8, 16, 12, 30, 45, 123456), id="a/b+c")
+        )
+        assert "+" not in encoded
+        assert "/" not in encoded
+
+
+class TestRejectsBadInput:
+    @pytest.mark.parametrize("bad", ["not-base64!!", "", "YWJj", "eyJhIjoxfQ=="])
+    def test_raises_on_malformed(self, bad):
+        # A client sending a stale or hand-written cursor must get a clean 400
+        # from the endpoint, not a 500 from a stray ValueError deeper in.
+        with pytest.raises(ValueError):
+            decode_cursor(bad)
+
+    def test_rejects_an_id_containing_the_separator(self):
+        # Ids are UUIDs today, but encoding must not silently corrupt if that
+        # ever stops being true.
+        original = Cursor(created_at=datetime(2026, 8, 16), id="a|b")
+        assert decode_cursor(encode_cursor(original)) == original

--- a/agents-api/tests/test_pipeline_endpoints.py
+++ b/agents-api/tests/test_pipeline_endpoints.py
@@ -1,0 +1,357 @@
+"""The pipeline status and control API (CAR-159).
+
+Endpoints take their session via `Depends(get_db)` so these tests can override
+it with the transactional `db` fixture. Opening a session inside the handler
+instead would write on a separate connection, outside the fixture's transaction,
+and leave rows behind in the test database.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db.models import PipelineTask
+from app.db.session import get_db
+from app.main import app
+from app.pipeline.runs import create_run, ensure_stages
+from app.pipeline.stages import (
+    PipelineEntityType,
+    PipelineKind,
+    PipelineRunStatus,
+    PipelineStageName,
+    PipelineTaskStatus,
+)
+
+HEADERS = {"X-API-Key": "test-secret"}
+
+
+@pytest.fixture
+def client(db, monkeypatch):
+    from app.pipeline import runs
+    from app.tasks.queue import task_queue
+
+    app.dependency_overrides[get_db] = lambda: db
+
+    enqueued = []
+
+    async def fake_enqueue(task, **kwargs):
+        enqueued.append((task, kwargs))
+        return "job-id"
+
+    monkeypatch.setattr(task_queue, "enqueue", fake_enqueue)
+
+    # Patched on app.pipeline.runs, not app.pipeline.control: runs.py binds
+    # these names at import, so patching the source module leaves its reference
+    # pointing at the real function and the test opens a Redis connection.
+    monkeypatch.setattr(runs, "request_cancel", lambda run_id, client=None: None)
+    monkeypatch.setattr(runs, "clear_cancel", lambda run_id, client=None: None)
+
+    # Deliberately not `with TestClient(app)`: the context manager runs the
+    # lifespan, which opens a real arq pool against REDIS_URL and hangs the
+    # suite when nothing is listening. Tests want the routes, not the app's
+    # startup side effects.
+    test_client = TestClient(app)
+    test_client.enqueued = enqueued
+    yield test_client
+
+    app.dependency_overrides.clear()
+
+
+def _seed_run(db, status=PipelineRunStatus.RUNNING, kind=PipelineKind.REFRESH_EXISTING):
+    run = create_run(db, kind=kind)
+    db.flush()
+    run.status = status
+    ensure_stages(db, run)
+    db.flush()
+    return run
+
+
+def _seed_tasks(db, run, stage_name, entities):
+    from app.pipeline.executor import materialize_tasks
+    from app.pipeline.runs import stage_row
+
+    stage = stage_row(db, run, stage_name)
+    materialize_tasks(db, run, stage, list(entities), PipelineEntityType.ALUMNI)
+    db.flush()
+    return stage
+
+
+class TestAuth:
+    def test_rejects_a_request_without_the_api_key(self, client, db):
+        assert client.get("/api/pipelines/runs").status_code == 401
+
+
+class TestListRuns:
+    def test_returns_runs_newest_first(self, client, db):
+        older = _seed_run(db)
+        newer = _seed_run(db)
+        older.created_at = datetime(2026, 1, 1)
+        newer.created_at = datetime(2026, 6, 1)
+        db.flush()
+
+        body = client.get("/api/pipelines/runs", params={"limit": 100}, headers=HEADERS).json()
+
+        ids = [item["id"] for item in body["items"]]
+        assert ids.index(newer.id) < ids.index(older.id)
+
+    def test_filters_by_status(self, client, db):
+        running = _seed_run(db, status=PipelineRunStatus.RUNNING)
+        _seed_run(db, status=PipelineRunStatus.COMPLETED)
+
+        body = client.get(
+            "/api/pipelines/runs", params={"status": "RUNNING"}, headers=HEADERS
+        ).json()
+
+        assert [item["id"] for item in body["items"]] == [running.id]
+
+    def test_pages_with_a_cursor(self, client, db):
+        seeded = []
+        for offset in range(5):
+            run = _seed_run(db)
+            run.created_at = datetime(2026, 6, 1) + timedelta(minutes=offset)
+            seeded.append(run)
+        db.flush()
+
+        first = client.get("/api/pipelines/runs", params={"limit": 2}, headers=HEADERS).json()
+        assert len(first["items"]) == 2
+        assert first["next_cursor"]
+
+        second = client.get(
+            "/api/pipelines/runs",
+            params={"limit": 2, "cursor": first["next_cursor"]},
+            headers=HEADERS,
+        ).json()
+
+        # A cursor that overlapped or skipped would show up as a repeated id.
+        first_ids = {item["id"] for item in first["items"]}
+        second_ids = {item["id"] for item in second["items"]}
+        assert first_ids.isdisjoint(second_ids)
+
+    def test_the_last_page_has_no_cursor(self, client, db):
+        _seed_run(db)
+
+        body = client.get("/api/pipelines/runs", params={"limit": 50}, headers=HEADERS).json()
+
+        assert body["next_cursor"] is None
+
+    def test_a_malformed_cursor_is_a_client_error(self, client, db):
+        response = client.get(
+            "/api/pipelines/runs", params={"cursor": "not-a-cursor!!"}, headers=HEADERS
+        )
+        assert response.status_code == 400
+
+
+class TestRunDetail:
+    def test_includes_every_stage(self, client, db):
+        run = _seed_run(db)
+
+        body = client.get(f"/api/pipelines/runs/{run.id}", headers=HEADERS).json()
+
+        assert [stage["stage"] for stage in body["stages"]] == [
+            "PLAN",
+            "LINKEDIN",
+            "COMPANY",
+            "CLASSIFY_ROLES",
+            "SENIORITY",
+            "LOCATION",
+        ]
+
+    def test_reports_task_counts(self, client, db):
+        run = _seed_run(db)
+        stage = _seed_tasks(db, run, PipelineStageName.CLASSIFY_ROLES, ["a", "b", "c"])
+        db.query(PipelineTask).filter(
+            PipelineTask.stage_id == stage.id, PipelineTask.entity_id == "a"
+        ).one().status = PipelineTaskStatus.FAILED
+        db.flush()
+
+        body = client.get(f"/api/pipelines/runs/{run.id}", headers=HEADERS).json()
+
+        assert body["counts"]["total"] == 3
+        assert body["counts"]["failed"] == 1
+
+    def test_unknown_run_is_a_404(self, client, db):
+        response = client.get(
+            "/api/pipelines/runs/00000000-0000-0000-0000-000000000000", headers=HEADERS
+        )
+        assert response.status_code == 404
+
+
+class TestTaskList:
+    def test_filters_by_status(self, client, db):
+        run = _seed_run(db)
+        stage = _seed_tasks(db, run, PipelineStageName.CLASSIFY_ROLES, ["a", "b"])
+        db.query(PipelineTask).filter(
+            PipelineTask.stage_id == stage.id, PipelineTask.entity_id == "a"
+        ).one().status = PipelineTaskStatus.FAILED
+        db.flush()
+
+        body = client.get(
+            f"/api/pipelines/runs/{run.id}/tasks",
+            params={"status": "FAILED"},
+            headers=HEADERS,
+        ).json()
+
+        assert [item["entity_id"] for item in body["items"]] == ["a"]
+
+    def test_filters_by_stage(self, client, db):
+        run = _seed_run(db)
+        _seed_tasks(db, run, PipelineStageName.CLASSIFY_ROLES, ["a"])
+        _seed_tasks(db, run, PipelineStageName.SENIORITY, ["b"])
+
+        body = client.get(
+            f"/api/pipelines/runs/{run.id}/tasks",
+            params={"stage": "SENIORITY"},
+            headers=HEADERS,
+        ).json()
+
+        assert [item["entity_id"] for item in body["items"]] == ["b"]
+
+    def test_exposes_the_error_so_a_failure_can_be_diagnosed(self, client, db):
+        run = _seed_run(db)
+        stage = _seed_tasks(db, run, PipelineStageName.CLASSIFY_ROLES, ["a"])
+        task = db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).one()
+        task.status = PipelineTaskStatus.FAILED
+        task.error = "RuntimeError: provider blew up"
+        db.flush()
+
+        body = client.get(f"/api/pipelines/runs/{run.id}/tasks", headers=HEADERS).json()
+
+        assert body["items"][0]["error"] == "RuntimeError: provider blew up"
+
+
+class TestRetry:
+    def test_requeues_only_failed_tasks(self, client, db):
+        run = _seed_run(db)
+        stage = _seed_tasks(db, run, PipelineStageName.CLASSIFY_ROLES, ["a", "b", "c"])
+        rows = {
+            row.entity_id: row
+            for row in db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).all()
+        }
+        rows["a"].status = PipelineTaskStatus.SUCCEEDED
+        rows["b"].status = PipelineTaskStatus.FAILED
+        rows["c"].status = PipelineTaskStatus.SKIPPED
+        db.flush()
+
+        client.post(f"/api/pipelines/runs/{run.id}/retry", headers=HEADERS)
+
+        after = {
+            row.entity_id: row.status
+            for row in db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).all()
+        }
+        assert after["b"] is PipelineTaskStatus.QUEUED
+        # Succeeded work must never be redone - that is the double-spend this
+        # whole endpoint exists to avoid.
+        assert after["a"] is PipelineTaskStatus.SUCCEEDED
+        assert after["c"] is PipelineTaskStatus.SKIPPED
+
+    def test_enqueues_the_earliest_stage_holding_a_failure(self, client, db):
+        run = _seed_run(db)
+        late = _seed_tasks(db, run, PipelineStageName.SENIORITY, ["b"])
+        early = _seed_tasks(db, run, PipelineStageName.COMPANY, ["a"])
+        for stage in (early, late):
+            for row in db.query(PipelineTask).filter(PipelineTask.stage_id == stage.id).all():
+                row.status = PipelineTaskStatus.FAILED
+        db.flush()
+
+        client.post(f"/api/pipelines/runs/{run.id}/retry", headers=HEADERS)
+
+        assert client.enqueued == [("run_stage", {"run_id": run.id, "stage": "COMPANY"})]
+
+    def test_a_run_with_no_failures_enqueues_nothing(self, client, db):
+        run = _seed_run(db)
+        stage = _seed_tasks(db, run, PipelineStageName.CLASSIFY_ROLES, ["a"])
+        db.query(PipelineTask).filter(
+            PipelineTask.stage_id == stage.id
+        ).one().status = PipelineTaskStatus.SUCCEEDED
+        db.flush()
+
+        response = client.post(f"/api/pipelines/runs/{run.id}/retry", headers=HEADERS)
+
+        assert response.json()["enqueued_stage"] is None
+        assert client.enqueued == []
+
+
+class TestResumeAndCancel:
+    def test_resume_reopens_from_the_named_stage(self, client, db):
+        run = _seed_run(db)
+
+        response = client.post(
+            f"/api/pipelines/runs/{run.id}/resume",
+            params={"from_stage": "COMPANY"},
+            headers=HEADERS,
+        )
+
+        assert response.status_code == 202
+        assert client.enqueued == [("run_stage", {"run_id": run.id, "stage": "COMPANY"})]
+
+    def test_resume_requires_a_stage(self, client, db):
+        run = _seed_run(db)
+        response = client.post(f"/api/pipelines/runs/{run.id}/resume", headers=HEADERS)
+        assert response.status_code == 422
+
+    def test_cancel_marks_the_run_cancelled(self, client, db):
+        run = _seed_run(db)
+
+        response = client.post(f"/api/pipelines/runs/{run.id}/cancel", headers=HEADERS)
+
+        assert response.status_code == 202
+        assert run.status is PipelineRunStatus.CANCELLED
+
+
+class TestCreateRun:
+    def test_creates_a_run_and_enqueues_the_first_stage(self, client, db):
+        response = client.post(
+            "/api/pipelines/REFRESH_EXISTING/runs",
+            json={"alumni_ids": "a,b"},
+            headers=HEADERS,
+        )
+
+        assert response.status_code == 202
+        run_id = response.json()["run_id"]
+        assert client.enqueued == [("run_stage", {"run_id": run_id, "stage": "PLAN"})]
+
+    def test_records_the_params_on_the_run(self, client, db):
+        from app.db.models import PipelineRun
+
+        response = client.post(
+            "/api/pipelines/REFRESH_EXISTING/runs",
+            json={"alumni_ids": "a,b", "failure_threshold": 0.5},
+            headers=HEADERS,
+        )
+
+        run = db.get(PipelineRun, response.json()["run_id"])
+        assert run.params["alumni_ids"] == "a,b"
+        assert run.params["failure_threshold"] == 0.5
+
+    def test_rejects_an_unknown_kind(self, client, db):
+        assert (
+            client.post("/api/pipelines/NONSENSE/runs", json={}, headers=HEADERS).status_code == 422
+        )
+
+
+class TestOpenAPIContract:
+    def test_every_pipeline_response_has_a_schema(self, client):
+        """Acceptance criterion 2, and the thing CAR-162's SDK depends on.
+
+        An endpoint added without a response_model produces a 2xx with no
+        schema, which generates an `any`-typed client method and is invisible
+        until someone tries to use it.
+        """
+        spec = client.get("/openapi.json", headers=HEADERS).json()
+
+        untyped = []
+        for path, operations in spec["paths"].items():
+            if not path.startswith("/api/pipelines"):
+                continue
+            for method, operation in operations.items():
+                for code, response in operation.get("responses", {}).items():
+                    if not code.startswith("2"):
+                        continue
+                    schema = (
+                        response.get("content", {}).get("application/json", {}).get("schema", {})
+                    )
+                    if not schema.get("$ref") and not schema.get("items"):
+                        untyped.append(f"{method.upper()} {path} -> {code}")
+
+        assert untyped == []


### PR DESCRIPTION
The read and control surface over pipeline runs, shaped so the phase-2 admin UI is additive: list, detail, drill into failures, act.

Closes CAR-159. Also adds a lint workflow for the two TypeScript workspaces.

## Endpoints

| Endpoint | Behaviour |
|---|---|
| `POST /api/pipelines/{kind}/runs` | Create a run, its stages, and enqueue the first |
| `GET /api/pipelines/runs` | Filter `kind` / `status`, cursor-paginated |
| `GET /api/pipelines/runs/{id}` | Detail with the stage breakdown and counts |
| `GET /api/pipelines/runs/{id}/tasks` | Filter `status` / `stage`, cursor-paginated |
| `POST /api/pipelines/runs/{id}/retry` | Re-run only what failed |
| `POST /api/pipelines/runs/{id}/resume` | Reopen a stage and everything after it |
| `POST /api/pipelines/runs/{id}/cancel` | Stop at the next chunk boundary |

## Design decisions worth reviewing

**`Page[T]` is a Pydantic generic.** This is the least conventional choice here and the one that matters most: FastAPI emits a distinct named schema per instantiation, so `/openapi.json` carries `Page_RunSummary_` and `Page_TaskSummary_`. Without it CAR-162's generated TypeScript client types these as `any` and the SDK is no better than untyped fetch. A test walks every 2xx under `/api/pipelines` and fails on any response lacking a schema `$ref` — that rot is invisible until someone tries to use the generated client, which is exactly how CAR-79 happened on the NestJS side.

**Keyset pagination, not offset.** The cursor is an opaque base64 of `(created_at, id)`, so the ordering can change without breaking an SDK that has already shipped, and paging does not drift as rows are inserted mid-scroll. The id is length-prefixed before encoding for the same reason the idempotency key is: a separator inside an id would otherwise decode to a different cursor.

**retry and resume both ship, because they answer different questions.** `retry` returns FAILED tasks to QUEUED run-wide and enqueues the earliest stage holding a failure; SUCCEEDED and SKIPPED are never touched, since redoing succeeded work is the double-spend the endpoint exists to avoid. `resume` reopens a named stage onwards. `resume` and `cancel` are thin wrappers over functions CAR-157 already shipped with tests.

**Sessions arrive via `Depends(get_db)`** rather than being opened in the handler, so a request owns its transaction and tests can substitute the transactional fixture. Note `get_db` does not commit, so writes commit explicitly — the same trap that cost CAR-157 three bugs.

**`POST /job-classification` reverts** to enqueuing its coarse task, and `classify_alumni_roles` is restored. CAR-157 had made it create a run; with a generic create endpoint there would be two paths creating runs and two ways to do one thing in the SDK. This is a partial revert of the previous PR and is deliberate.

**No new auth.** `APIKeyMiddleware` already covers every path except `/health`. The user-level admin check belongs in NestJS when it proxies — agents-api has no user context and should not grow one.

## Two defects found while writing the tests

**`APIKeyMiddleware` never returned 401.** An `HTTPException` raised inside a `BaseHTTPMiddleware` is not seen by FastAPI's exception handler — that runs inside the router, further in — so it bubbled to `ServerErrorMiddleware` and the client got a 500. A missing or wrong API key read as "the server broke" rather than "you are not authorised". It now returns the response instead of raising. Pre-existing and unrelated to this ticket.

**Run counts were always zero before execution.** They were summed from `PipelineStage`'s counters, which only the executor writes, so a run created but not yet executed reported zero tasks while plainly having them. Now counted from the task rows, in one grouped query per page rather than one per run.

## Verified against a live server

Not just TestClient — the API run against local Postgres and Redis:

* missing key and wrong key both return **401** (the fix above, confirmed end to end)
* unknown run **404**, malformed cursor **400**, bad kind and missing `from_stage` **422**
* cursor pages come back disjoint — no overlap, no skips
* on a run with 3 SUCCEEDED / 2 FAILED / 1 SKIPPED, `retry` moved **only the two FAILED** to QUEUED with their errors cleared, left the rest untouched, and enqueued `CLASSIFY_ROLES`
* `/openapi.json` carries `Page_RunSummary_` and `Page_TaskSummary_`, and every 2xx resolves to a real schema

All four acceptance criteria met.

```
186 passed, 2 xfailed
ruff check app/ --select F: clean
ruff check + format tests/: clean
```

## The lint workflow

agents-api has had a lint step since CAR-154, but nothing ran `oxlint` or `next lint` over the NestJS and Next.js workspaces despite both defining the scripts.

The paths filter gates the jobs rather than the trigger, following `agents-api-tests.yml`: a workflow that never runs never reports, and a required check that never reports blocks the PR forever. Installs are scoped with `--filter <workspace>...`, and the api job runs `prisma:generate` first because oxlint resolves imports of the generated client.

Both workspaces pass today, so this gates regressions rather than starting red. The existing warnings are tracked in CAR-88 and CAR-92.

## Follow-ups

* CAR-162 (typed SDK) is unblocked by this.
* `POST /{kind}/runs` enqueues `PLAN`, which is a no-op until CAR-158 fills it in; the chain skips it and proceeds.
* CAR-172 still applies — a crashed run needs an explicit resume, which now has an endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YPiRLJUH3sP1gC13o1zYq
