### PR TITLE
feat(db): add Company.enrichedAt for refresh planning (CAR-152)

### DIFF
--- a/agents-api/app/core/config.py
+++ b/agents-api/app/core/config.py
@@ -30,6 +30,11 @@ class Settings(BaseSettings):
     # Redis Settings
     REDIS_URL: str = "redis://localhost:6379/0"
 
+    # Pipeline Settings
+    # How long a company's enrichment stays fresh. In config rather than
+    # hardcoded so it can be tuned without a deploy (CAR-152).
+    COMPANY_REFRESH_AFTER_DAYS: int = 180
+
     # OpenAI Settings
     OPENAI_DEFAULT_MODEL: str = "gpt-4o-mini"
     OPENAI_API_KEY: str = ""

--- a/agents-api/app/db/models.py
+++ b/agents-api/app/db/models.py
@@ -144,6 +144,10 @@ class Company(Base):
     created_by = Column(String, nullable=True)
     updated_by = Column(String, nullable=True)
 
+    # Null means never enriched, so the row is always eligible. Not updated_at:
+    # that is bumped by any write, including an HQ location resolution.
+    enriched_at = Column(DateTime, nullable=True)
+
     industry = relationship("Industry", back_populates="companies")
     roles = relationship("Role", back_populates="company")
     hq_location = relationship("Location", back_populates="company")

--- a/agents-api/app/pipeline/refresh.py
+++ b/agents-api/app/pipeline/refresh.py
@@ -1,0 +1,38 @@
+"""Whether an entity's enrichment is stale enough to redo.
+
+Pure, so CAR-158's planner can partition a whole table without a database round
+trip per row, and so the rule that decides what a run spends money on is
+testable without infrastructure.
+"""
+
+import enum
+from datetime import datetime, timedelta
+from typing import Optional
+
+
+class RefreshDecision(str, enum.Enum):
+    ENRICH = "ENRICH"
+    REFRESH = "REFRESH"
+    SKIP = "SKIP"
+
+
+def refresh_decision(
+    enriched_at: Optional[datetime], now: datetime, after_days: int
+) -> RefreshDecision:
+    """Classify one entity by how long ago it was enriched.
+
+    ENRICH and REFRESH both mean work, but they are distinct because a plan that
+    says "47 never enriched, 88 stale" reads very differently from one that says
+    "135 companies" - and the first is the one worth approving.
+
+    Boundary is inclusive: exactly `after_days` old still counts as fresh. A
+    timestamp in the future is treated as fresh rather than as work, so clock
+    skew between the worker and the database cannot trigger a re-enrichment.
+    """
+    if enriched_at is None:
+        return RefreshDecision.ENRICH
+
+    if enriched_at >= now - timedelta(days=after_days):
+        return RefreshDecision.SKIP
+
+    return RefreshDecision.REFRESH

--- a/agents-api/app/services/company.py
+++ b/agents-api/app/services/company.py
@@ -14,6 +14,7 @@ from app.services.image_storage import image_storage_service
 from app.utils.company_db import (
     get_all_companies,
     get_companies_by_ids,
+    mark_company_enriched,
     update_company,
 )
 from app.utils.consts import BASE_WAIT_TIME, DEFAULT_INDUSTRY_ID
@@ -267,6 +268,10 @@ class CompanyService:
             # attached to any session and can be written through a fresh one.
             with session_scope() as db:
                 update_company(company, db)
+                # Marked here rather than inside update_company: the location
+                # agent calls that helper too, and enrichment is what this
+                # timestamp is meant to record (CAR-152).
+                mark_company_enriched(company_id, db)
 
             # Now that the company is updated, trigger location processing
             if company_response.headquarters and company_response.country_code:

--- a/agents-api/app/utils/company_db.py
+++ b/agents-api/app/utils/company_db.py
@@ -72,3 +72,20 @@ def update_company(company: Company, db: Session) -> Company:
         db.commit()
         db.refresh(existing_company)
     return existing_company
+
+
+def mark_company_enriched(company_id: str, db: Session) -> None:
+    """Record that enrichment succeeded for this company.
+
+    Separate from `update_company` on purpose. That helper is also called by the
+    location agent to attach an HQ location, and marking a company enriched
+    there would make a never-enriched company look fresh - the same defect
+    `updated_at` already has, which is why this column exists.
+    """
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if company is None:
+        logger.warning("Cannot mark company %s enriched: no such company", company_id)
+        return
+
+    company.enriched_at = datetime.now(timezone.utc)
+    db.commit()

--- a/agents-api/tests/test_company_enriched_at.py
+++ b/agents-api/tests/test_company_enriched_at.py
@@ -1,0 +1,85 @@
+"""Company.enrichedAt is written by enrichment and nothing else (CAR-152).
+
+The column exists because `updatedAt` is bumped by any write and so cannot say
+whether a company was ever *enriched*. That distinction only holds if the write
+site is the enrichment path alone, which is what these tests pin down:
+`update_company` has two callers, and only one of them is enrichment.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.db.models import Company, Industry
+from app.utils.company_db import mark_company_enriched, update_company
+
+
+@pytest.fixture
+def industry(db):
+    row = Industry(name="Test Industry")
+    db.add(row)
+    db.flush()
+    return row
+
+
+@pytest.fixture
+def company(db, industry):
+    row = Company(name="Acme", industry_id=industry.id)
+    db.add(row)
+    db.flush()
+    return row
+
+
+class TestMarkCompanyEnriched:
+    def test_sets_the_timestamp(self, db, company):
+        assert company.enriched_at is None
+
+        mark_company_enriched(company.id, db)
+        db.refresh(company)
+
+        assert company.enriched_at is not None
+
+    def test_the_timestamp_is_now(self, db, company):
+        before = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=5)
+
+        mark_company_enriched(company.id, db)
+        db.refresh(company)
+
+        assert company.enriched_at >= before
+
+    def test_moves_the_timestamp_forward_on_re_enrichment(self, db, company):
+        company.enriched_at = datetime(2020, 1, 1)
+        db.flush()
+
+        mark_company_enriched(company.id, db)
+        db.refresh(company)
+
+        assert company.enriched_at > datetime(2020, 1, 1)
+
+    def test_an_unknown_company_is_not_an_error(self, db):
+        # Enrichment races deletion rarely, but a missing row must not take the
+        # whole stage down after the work has already been paid for.
+        mark_company_enriched("00000000-0000-0000-0000-000000000000", db)
+
+
+class TestUpdateCompanyLeavesItAlone:
+    def test_a_plain_update_does_not_mark_the_company_enriched(self, db, company, industry):
+        # agents/location.py calls update_company to attach an HQ location. If
+        # that set enriched_at, a company that was never enriched would look
+        # fresh and the planner would skip it forever - which is exactly the
+        # failure mode updatedAt already has.
+        update_company(Company(id=company.id, name="Acme Updated"), db)
+        db.refresh(company)
+
+        assert company.name == "Acme Updated"
+        assert company.enriched_at is None
+
+    def test_a_plain_update_does_not_clear_an_existing_timestamp(self, db, company):
+        stamped = datetime(2026, 1, 1)
+        company.enriched_at = stamped
+        db.flush()
+
+        update_company(Company(id=company.id, name="Acme Again"), db)
+        db.refresh(company)
+
+        assert company.enriched_at == stamped

--- a/agents-api/tests/test_company_refresh.py
+++ b/agents-api/tests/test_company_refresh.py
@@ -1,0 +1,58 @@
+"""Company staleness decisions (CAR-152).
+
+Pure: the rule that decides whether a company needs enriching is the thing
+CAR-158's planner asks before spending money, so it is worth being certain about
+without needing a database to ask.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.pipeline.refresh import RefreshDecision, refresh_decision
+
+NOW = datetime(2026, 8, 16, 12, 0, 0)
+AFTER_DAYS = 180
+
+
+class TestNeverEnriched:
+    def test_a_company_with_no_timestamp_is_enriched(self):
+        # NULL is the backfill value for every existing row, so this is the
+        # decision the first planned run makes about almost the whole table.
+        assert refresh_decision(None, now=NOW, after_days=AFTER_DAYS) is RefreshDecision.ENRICH
+
+
+class TestStaleness:
+    def test_older_than_the_threshold_is_refreshed(self):
+        enriched = NOW - timedelta(days=AFTER_DAYS + 1)
+        assert refresh_decision(enriched, now=NOW, after_days=AFTER_DAYS) is RefreshDecision.REFRESH
+
+    def test_newer_than_the_threshold_is_skipped(self):
+        enriched = NOW - timedelta(days=AFTER_DAYS - 1)
+        assert refresh_decision(enriched, now=NOW, after_days=AFTER_DAYS) is RefreshDecision.SKIP
+
+    def test_exactly_at_the_threshold_is_skipped(self):
+        # Inclusive boundary, stated so it is a decision rather than an
+        # accident of which comparison operator got typed.
+        enriched = NOW - timedelta(days=AFTER_DAYS)
+        assert refresh_decision(enriched, now=NOW, after_days=AFTER_DAYS) is RefreshDecision.SKIP
+
+    def test_a_future_timestamp_is_skipped(self):
+        # Clock skew between the worker and the database should not cause an
+        # expensive re-enrichment.
+        enriched = NOW + timedelta(days=1)
+        assert refresh_decision(enriched, now=NOW, after_days=AFTER_DAYS) is RefreshDecision.SKIP
+
+
+class TestThresholdIsHonoured:
+    @pytest.mark.parametrize("after_days", [0, 1, 30, 365])
+    def test_the_threshold_is_read_not_assumed(self, after_days):
+        enriched = NOW - timedelta(days=after_days, seconds=1)
+        assert refresh_decision(enriched, now=NOW, after_days=after_days) is RefreshDecision.REFRESH
+
+    def test_a_zero_threshold_refreshes_anything_already_enriched(self):
+        # The FULL refresh mode CAR-158 describes, expressed as a threshold.
+        assert (
+            refresh_decision(NOW - timedelta(seconds=1), now=NOW, after_days=0)
+            is RefreshDecision.REFRESH
+        )

--- a/api/prisma/migrations/20260816192625_add_company_enriched_at/migration.sql
+++ b/api/prisma/migrations/20260816192625_add_company_enriched_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "company" ADD COLUMN     "enriched_at" TIMESTAMP(6);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -70,6 +70,12 @@ model Company {
   updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamp(6)
   updatedBy String?  @map("updated_by")
 
+  /// When enrichment last succeeded for this company. Null means never, so the
+  /// row is always eligible. Deliberately not updatedAt: that is bumped by any
+  /// write, including a merge or an HQ location resolution, which would mark a
+  /// never-enriched company as fresh.
+  enrichedAt DateTime? @map("enriched_at") @db.Timestamp(6)
+
   Industry      Industry        @relation(fields: [industryId], references: [id])
   roles         Role[]
   ReviewCompany ReviewCompany[]


### PR DESCRIPTION
The staleness signal the PLAN stage needs. Unblocks CAR-158.

Closes CAR-152.

## Why a new column rather than `updatedAt`

`updatedAt` is bumped by any write. A company that was merged, had its logo changed, or had its HQ location resolved would read as freshly enriched despite never having been enriched at all — so the planner would skip it forever.

## The trap this ticket is really about

`update_company` has **two** callers: the enrichment service (`services/company.py:269`) and the location agent attaching an HQ location (`agents/location.py:455`). Setting `enrichedAt` inside that shared helper would have reintroduced the exact defect the column exists to avoid.

So it is written by `mark_company_enriched`, called only from the enrichment path. Two tests pin that down — one asserting a plain `update_company` does not set it, another asserting it does not clear an existing value. Nothing about the code makes this obvious, which is why it is tested rather than commented.

## The migration

```sql
ALTER TABLE "company" ADD COLUMN "enriched_at" TIMESTAMP(6);
```

One additive nullable column. No `DROP`, `TRUNCATE` or `DELETE`, and no backfill needed since `NULL` already means "never enriched" and therefore always eligible.

Rehearsed against a local database carrying 2472 companies:

* the column matches the SQLAlchemy mirror in both type and nullability
* all 2472 existing rows read as eligible, which is the intended starting state
* enrichment sets it, re-enrichment moves it forward, and a missing company is a warning rather than a crash — a race with deletion must not take down a stage after the work has already been paid for

**Production is not migrated.** Railway picks this up via `prisma migrate deploy` on the next API deploy after merge, same as CAR-155.

## `refresh_decision`

A pure function partitioning a company into `ENRICH`, `REFRESH` or `SKIP`. Slightly beyond a literal reading of the ticket, but acceptance criterion 3 asks that the planner *can* partition, and this is the difference between a column existing and the planner being able to use it. Being pure, CAR-158 can classify the whole table without a round trip per row, and the rule that decides what a run spends money on is testable in milliseconds.

`ENRICH` and `REFRESH` stay distinct because a plan reading "47 never enriched, 88 stale" is far more approvable than one reading "135 companies".

Two boundaries are decisions rather than accidents, and are named as tests:

* exactly at the threshold counts as fresh
* a timestamp in the future is fresh rather than work, so clock skew between the worker and the database cannot trigger a paid-for re-enrichment

`COMPANY_REFRESH_AFTER_DAYS` defaults to 180 and lives in config so it is tunable without a deploy.

## Not doing

No index on `enriched_at`. The table is ~2.5k rows, so a sequential scan costs nothing, and CAR-72 already audited indexes. Easy to add if planning ever gets slow.

```
202 passed, 2 xfailed
ruff check app/ --select F: clean
ruff check + format tests/: clean
```

## Follow-up

CAR-174 files the `Alumni` equivalent (`linkedinPulledAt`), which CAR-158 needs for the LINKEDIN stage's staleness rule and which this ticket explicitly asked to be filed separately. It carries a note to re-check the two-caller trap, since `_persist_profile_data` sits under both the extract and update paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YPiRLJUH3sP1gC13o1zYq
